### PR TITLE
Fix README, add checkpoint download + predict script

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ uv run python scripts/evaluate.py
 
 The evaluation script computes retrieval metrics (Top-K hit rates, MRR) on the held-out test set. Checkpoints are also saved during training to the `checkpoints/` directory.
 
+### Query with a Reaction
+
+Find the most likely catalyzing enzymes for a reaction SMILES, searching the bundled set of ~216K proteins with pre-computed ProtT5-XL embeddings:
+
+```bash
+uv run python scripts/predict.py "CC(=O)SCoA.OC(CC([O-])=O)CC([O-])=O>>CC(=O)CC(CC([O-])=O)([O-])=O.CoA" --top-k 10
+```
+
+Use `--bidirectional` to score both forward and reverse reaction directions (averaged):
+
+```bash
+uv run python scripts/predict.py "SMILES>>SMILES" --bidirectional --top-k 20
+```
+
 ### Train the Model
 
 Train the SOTA model from scratch (requires ~16GB RAM, single GPU with 16GB+ VRAM):
@@ -109,6 +123,7 @@ horizyn/
 ├── scripts/                   # Helper scripts
 │   ├── download_training_data.py  # Training data download
 │   ├── download_checkpoint.py     # Pre-trained checkpoint download
+│   ├── predict.py                 # Query model with a reaction SMILES
 │   └── evaluate.py                # Model evaluation
 ├── train.py                   # Main training entry point
 └── tests/                     # Test suite

--- a/README.md
+++ b/README.md
@@ -44,27 +44,33 @@ Download the training dataset and protein embeddings (~1GB). This provides the ~
 uv run python scripts/download_training_data.py
 ```
 
-### Download Pre-trained Checkpoint
+### Download Pre-trained Checkpoints
 
-Download the official pre-trained checkpoint (~201MB):
+Download both official checkpoints (~201MB each, ~402MB total):
 
 ```bash
 uv run python scripts/download_checkpoint.py
 ```
 
+This downloads two checkpoints:
+- **`horizyn_v1_0_dev.ckpt`** — trained on the train split only (paper-faithful); use for evaluation
+- **`horizyn_v1_0_inf.ckpt`** — trained on full data; use for prediction
+
+To download only one: `uv run python scripts/download_checkpoint.py --only dev`
+
 ### Evaluate the Model
 
-Evaluate the pre-trained checkpoint on the test set (requires both the dataset and checkpoint above):
+Evaluate the dev checkpoint on the test set (requires both the dataset and dev checkpoint above):
 
 ```bash
 uv run python scripts/evaluate.py
 ```
 
-The evaluation script computes retrieval metrics (Top-K hit rates, MRR) on the held-out test set.
+The evaluation script computes retrieval metrics (Top-K hit rates, MRR) on the held-out test set. Expected: top-1 ≈ 32.4%.
 
 ### Query with a Reaction
 
-Find the most likely catalyzing enzymes for a reaction SMILES, searching the bundled set of ~216K proteins (requires both the dataset and checkpoint above):
+Find the most likely catalyzing enzymes for a reaction SMILES, using the inference checkpoint against the bundled ~216K protein embeddings (requires both the dataset and inf checkpoint above):
 
 ```bash
 # Example: ADP + H2O -> AMP + phosphate

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Train the SOTA model from scratch (requires ~16GB RAM, single GPU with 16GB+ VRA
 uv run python train.py --config configs/sota.yaml
 ```
 
+### Run Tests
+
+```bash
+uv run pytest
+```
+
 ## Hardware Requirements
 
 - **RAM**: 8GB minimum (4GB for data loaded entirely in memory)

--- a/README.md
+++ b/README.md
@@ -38,29 +38,37 @@ pip install -e .
 
 ### Download Dataset
 
-Download the SOTA dataset (~1GB):
+Download the SOTA training dataset (~1GB):
 
 ```bash
-python scripts/download_data.py
+uv run python scripts/download_training_data.py
 ```
 
-### Train the Model
+### Download Pre-trained Checkpoint
 
-Train the SOTA model (requires ~16GB RAM, single GPU with 16GB+ VRAM):
+Download the official pre-trained checkpoint (~370MB):
 
 ```bash
-python train.py --config configs/sota.yaml
+uv run python scripts/download_checkpoint.py
 ```
 
 ### Evaluate the Model
 
-Evaluate a trained model checkpoint on the test set:
+Evaluate the pre-trained checkpoint on the test set:
 
 ```bash
-python scripts/evaluate.py --checkpoint checkpoints/epoch=99-step=XXXXX.ckpt
+uv run python scripts/evaluate.py
 ```
 
-The evaluation script computes retrieval metrics (Top-K hit rates, MRR) on the held-out test set. Checkpoints are saved during training to the `checkpoints/` directory.
+The evaluation script computes retrieval metrics (Top-K hit rates, MRR) on the held-out test set. Checkpoints are also saved during training to the `checkpoints/` directory.
+
+### Train the Model
+
+Train the SOTA model from scratch (requires ~16GB RAM, single GPU with 16GB+ VRAM):
+
+```bash
+uv run python train.py --config configs/sota.yaml
+```
 
 ## Hardware Requirements
 
@@ -99,7 +107,9 @@ horizyn/
 │   ├── sota.yaml             # SOTA configuration
 │   └── nano.yaml             # Small test configuration
 ├── scripts/                   # Helper scripts
-│   └── download_data.py      # Dataset download
+│   ├── download_training_data.py  # Training data download
+│   ├── download_checkpoint.py     # Pre-trained checkpoint download
+│   └── evaluate.py                # Model evaluation
 ├── train.py                   # Main training entry point
 └── tests/                     # Test suite
 ```

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ The evaluation script computes retrieval metrics (Top-K hit rates, MRR) on the h
 Find the most likely catalyzing enzymes for a reaction SMILES, searching the bundled set of ~216K proteins with pre-computed ProtT5-XL embeddings:
 
 ```bash
-uv run python scripts/predict.py "CC(=O)SCoA.OC(CC([O-])=O)CC([O-])=O>>CC(=O)CC(CC([O-])=O)([O-])=O.CoA" --top-k 10
+# Example: ADP + H2O -> AMP + phosphate
+uv run python scripts/predict.py "NC1=NC=NC2=C1N=CN2[C@@H]1O[C@H](COP(=O)([O-])[O-])[C@@H](OP(=O)([O-])[O-])[C@H]1O.[H]O[H]>>NC1=NC=NC2=C1N=CN2[C@@H]1O[C@H](COP(=O)([O-])[O-])[C@@H](O)[C@H]1O.O=P([O-])([O-])O" --top-k 10
 ```
 
 Use `--bidirectional` to score both forward and reverse reaction directions (averaged):

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ uv run python scripts/download_training_data.py
 
 ### Download Pre-trained Checkpoint
 
-Download the official pre-trained checkpoint (~370MB):
+Download the official pre-trained checkpoint (~201MB):
 
 ```bash
 uv run python scripts/download_checkpoint.py
@@ -143,12 +143,15 @@ The Horizyn model uses a dual-encoder architecture:
 If you use this code in your research, please cite:
 
 ```bibtex
-@article{horizyn2025,
+@article{horizyn2026,
   title = {Dual-encoder contrastive learning accelerates enzyme discovery},
   author = {Rocks, Jason W. and Truong, Dat P. and Rappoport, Dmitrij and Maddrell-Mander, Sam and Martin-Alarcon, Daniel A. and Lee, Toni and Crossan, Steve and Goldford, Joshua E.},
-  journal = {bioRxiv}
-  year = {2025},
-  doi = {10.1101/2025.08.21.671639},
+  journal = {Proc. Natl. Acad. Sci. U.S.A.},
+  volume = {123},
+  number = {12},
+  pages = {e2520070123},
+  year = {2026},
+  doi = {10.1073/pnas.2520070123},
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pip install -e .
 
 ### Download Dataset
 
-Download the SOTA training dataset (~1GB):
+Download the training dataset and protein embeddings (~1GB). This provides the ~216K pre-computed ProtT5-XL protein embeddings needed by both evaluation and prediction:
 
 ```bash
 uv run python scripts/download_training_data.py
@@ -54,17 +54,17 @@ uv run python scripts/download_checkpoint.py
 
 ### Evaluate the Model
 
-Evaluate the pre-trained checkpoint on the test set:
+Evaluate the pre-trained checkpoint on the test set (requires both the dataset and checkpoint above):
 
 ```bash
 uv run python scripts/evaluate.py
 ```
 
-The evaluation script computes retrieval metrics (Top-K hit rates, MRR) on the held-out test set. Checkpoints are also saved during training to the `checkpoints/` directory.
+The evaluation script computes retrieval metrics (Top-K hit rates, MRR) on the held-out test set.
 
 ### Query with a Reaction
 
-Find the most likely catalyzing enzymes for a reaction SMILES, searching the bundled set of ~216K proteins with pre-computed ProtT5-XL embeddings:
+Find the most likely catalyzing enzymes for a reaction SMILES, searching the bundled set of ~216K proteins (requires both the dataset and checkpoint above):
 
 ```bash
 # Example: ADP + H2O -> AMP + phosphate

--- a/configs/README.md
+++ b/configs/README.md
@@ -275,7 +275,7 @@ All metrics are logged to CSV files in the `logs/` directory.
 
 **Solutions**:
 - Verify all data paths in config point to existing files
-- Run `python scripts/download_data.py` if SOTA data missing
+- Run `python scripts/download_training_data.py` if SOTA data missing
 - Check that nanodata files exist for testing
 - Ensure file permissions allow reading
 

--- a/data/.gitkeep
+++ b/data/.gitkeep
@@ -1,3 +1,3 @@
 # This file ensures the data/ directory is tracked by git
-# Data files will be downloaded here via scripts/download_data.py
+# Data files will be downloaded here via scripts/download_training_data.py
 

--- a/data/sota/.gitkeep
+++ b/data/sota/.gitkeep
@@ -1,3 +1,3 @@
 # This file ensures the data/ directory is tracked by git
-# Data files will be downloaded here via scripts/download_data.py
+# Data files will be downloaded here via scripts/download_training_data.py
 

--- a/horizyn-user-manual.md
+++ b/horizyn-user-manual.md
@@ -69,7 +69,7 @@ horizyn/
 │   ├── sota.yaml             # SOTA configuration
 │   └── nano.yaml             # Small test configuration
 ├── scripts/                   # Helper scripts
-│   └── download_data.py      # Dataset download
+│   └── download_training_data.py      # Dataset download
 ├── train.py                   # Main training entry point
 └── tests/                     # Test suite
 ```
@@ -726,7 +726,7 @@ Other datasets use `rename_map` to adapt their schema to this standard without m
 uv sync
 
 # Download data
-python scripts/download_data.py
+python scripts/download_training_data.py
 ```
 
 #### 2. Training
@@ -1035,7 +1035,7 @@ Only run SOTA data tests when you need to validate with production data:
 
 ```bash
 # Download SOTA data first
-python scripts/download_data.py
+python scripts/download_training_data.py
 
 # Run SOTA data validation tests (< 5 seconds)
 pytest tests/integration/test_sota.py -v
@@ -1113,7 +1113,7 @@ pytest tests/unit/test_model.py::TestMLP::test_forward -v
 Run SOTA data validation tests (requires SOTA data):
 ```bash
 # Download data first
-python scripts/download_data.py
+python scripts/download_training_data.py
 
 # Run SOTA data tests
 pytest tests/integration/test_sota.py -v

--- a/scratch/.gitkeep
+++ b/scratch/.gitkeep
@@ -1,3 +1,3 @@
 # This file ensures the data/ directory is tracked by git
-# Data files will be downloaded here via scripts/download_data.py
+# Data files will be downloaded here via scripts/download_training_data.py
 

--- a/scripts/download_checkpoint.py
+++ b/scripts/download_checkpoint.py
@@ -12,8 +12,8 @@ The checkpoint can be used directly for evaluation:
     python scripts/evaluate.py --checkpoint checkpoints/horizyn-v1.ckpt
 
 Zenodo:
-    DOI: 10.5281/zenodo.17957034
-    Record: https://zenodo.org/records/17957034
+    DOI: 10.5281/zenodo.20348783
+    Record: https://zenodo.org/records/20348783
 """
 
 import argparse
@@ -29,14 +29,13 @@ except ImportError:
     print("Please install: pip install requests tqdm")
     sys.exit(1)
 
-ZENODO_RECORD_ID = 17957034
+ZENODO_RECORD_ID = 20348783
 ZENODO_API_BASE = f"https://zenodo.org/api/records/{ZENODO_RECORD_ID}"
 
-# Zenodo filename has a typo ("horyzin"); we save as the correct name locally.
-CHECKPOINT_ZENODO_KEY = "horyzin-v1.ckpt"
+CHECKPOINT_ZENODO_KEY = "horizyn_v1_0_dev.ckpt"
 CHECKPOINT_LOCAL_NAME = "horizyn-v1.ckpt"
 CHECKPOINT_MD5 = "5b1f938f8b0a82fbe91892a3b4e2bf2c"
-CHECKPOINT_SIZE_MB = 192
+CHECKPOINT_SIZE_MB = 201
 
 
 def download_file(url: str, output_path: Path) -> None:

--- a/scripts/download_checkpoint.py
+++ b/scripts/download_checkpoint.py
@@ -35,8 +35,8 @@ ZENODO_API_BASE = f"https://zenodo.org/api/records/{ZENODO_RECORD_ID}"
 # Zenodo filename has a typo ("horyzin"); we save as the correct name locally.
 CHECKPOINT_ZENODO_KEY = "horyzin-v1.ckpt"
 CHECKPOINT_LOCAL_NAME = "horizyn-v1.ckpt"
-CHECKPOINT_MD5 = "77d15d54bcb99655b4aa8126c3758fc7"
-CHECKPOINT_SIZE_MB = 370
+CHECKPOINT_MD5 = "5b1f938f8b0a82fbe91892a3b4e2bf2c"
+CHECKPOINT_SIZE_MB = 192
 
 
 def download_file(url: str, output_path: Path) -> None:

--- a/scripts/download_checkpoint.py
+++ b/scripts/download_checkpoint.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Download Horizyn Pre-trained Checkpoint
+
+Downloads the official pre-trained Horizyn v1 checkpoint from Zenodo.
+
+Usage:
+    python scripts/download_checkpoint.py
+    python scripts/download_checkpoint.py --output-dir checkpoints
+
+The checkpoint can be used directly for evaluation:
+    python scripts/evaluate.py --checkpoint checkpoints/horizyn-v1.ckpt
+
+Zenodo:
+    DOI: 10.5281/zenodo.17957034
+    Record: https://zenodo.org/records/17957034
+"""
+
+import argparse
+import hashlib
+import sys
+from pathlib import Path
+
+try:
+    import requests
+    from tqdm import tqdm
+except ImportError:
+    print("Error: Required packages not installed.")
+    print("Please install: pip install requests tqdm")
+    sys.exit(1)
+
+ZENODO_RECORD_ID = 17957034
+ZENODO_API_BASE = f"https://zenodo.org/api/records/{ZENODO_RECORD_ID}"
+
+# Zenodo filename has a typo ("horyzin"); we save as the correct name locally.
+CHECKPOINT_ZENODO_KEY = "horyzin-v1.ckpt"
+CHECKPOINT_LOCAL_NAME = "horizyn-v1.ckpt"
+CHECKPOINT_MD5 = "77d15d54bcb99655b4aa8126c3758fc7"
+CHECKPOINT_SIZE_MB = 370
+
+
+def download_file(url: str, output_path: Path) -> None:
+    """Download a file with progress bar."""
+    print(f"Downloading from: {url}")
+    print(f"Saving to: {output_path}")
+
+    try:
+        response = requests.get(url, stream=True)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        raise RuntimeError(f"Download failed: {e}")
+
+    total_size = int(response.headers.get("content-length", 0))
+
+    progress_bar = tqdm(
+        total=total_size,
+        unit="iB",
+        unit_scale=True,
+        desc=output_path.name,
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "wb") as f:
+        for chunk in response.iter_content(chunk_size=8192):
+            size = f.write(chunk)
+            progress_bar.update(size)
+
+    progress_bar.close()
+
+    if total_size != 0 and progress_bar.n != total_size:
+        raise RuntimeError("Download incomplete")
+
+    print(f"✓ Downloaded: {output_path.name}\n")
+
+
+def verify_checksum(file_path: Path, expected_md5: str) -> bool:
+    """Verify file MD5 checksum."""
+    print("Verifying md5 checksum...")
+
+    hasher = hashlib.md5()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            hasher.update(chunk)
+
+    actual = hasher.hexdigest()
+
+    if actual == expected_md5:
+        print(f"✓ Checksum verified: {actual}\n")
+        return True
+    else:
+        print(f"✗ Checksum mismatch!")
+        print(f"  Expected: {expected_md5}")
+        print(f"  Got:      {actual}\n")
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Download Horizyn pre-trained checkpoint from Zenodo",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="checkpoints",
+        help="Output directory (default: checkpoints)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force download even if file exists",
+    )
+
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    output_path = output_dir / CHECKPOINT_LOCAL_NAME
+
+    print("=" * 70)
+    print("HORIZYN CHECKPOINT DOWNLOAD")
+    print("=" * 70)
+    print(f"Checkpoint: {CHECKPOINT_LOCAL_NAME}")
+    print(f"Size: ~{CHECKPOINT_SIZE_MB} MB")
+    print(f"Output: {output_path}")
+    print("=" * 70 + "\n")
+
+    if output_path.exists() and not args.force:
+        print(f"Checkpoint already exists: {output_path}")
+        print("Use --force to re-download.\n")
+        if verify_checksum(output_path, CHECKPOINT_MD5):
+            print("✓ Checkpoint ready for evaluation!\n")
+            print("To evaluate, run:")
+            print(f"    python scripts/evaluate.py --checkpoint {output_path}")
+            return
+        else:
+            print("Existing file is corrupted. Re-downloading...\n")
+
+    url = f"{ZENODO_API_BASE}/files/{CHECKPOINT_ZENODO_KEY}/content"
+    download_file(url, output_path)
+
+    if not verify_checksum(output_path, CHECKPOINT_MD5):
+        print("Error: Checksum verification failed!")
+        print("The downloaded file may be corrupted.")
+        sys.exit(1)
+
+    size_mb = output_path.stat().st_size / (1024 * 1024)
+
+    print("=" * 70)
+    print("DOWNLOAD COMPLETE")
+    print("=" * 70)
+    print(f"✓ Checkpoint ready: {output_path} ({size_mb:.1f} MB)\n")
+    print("To evaluate, run:")
+    print(f"    python scripts/evaluate.py --checkpoint {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/download_checkpoint.py
+++ b/scripts/download_checkpoint.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 """
-Download Horizyn Pre-trained Checkpoint
+Download Horizyn Pre-trained Checkpoints
 
-Downloads the official pre-trained Horizyn v1 checkpoint from Zenodo.
+Downloads the official Horizyn v1 checkpoints from Zenodo:
+  - horizyn_v1_0_dev.ckpt  (paper-faithful, for evaluation)
+  - horizyn_v1_0_inf.ckpt  (full training data, for prediction)
 
 Usage:
     python scripts/download_checkpoint.py
+    python scripts/download_checkpoint.py --only dev
+    python scripts/download_checkpoint.py --only inf
     python scripts/download_checkpoint.py --output-dir checkpoints
-
-The checkpoint can be used directly for evaluation:
-    python scripts/evaluate.py --checkpoint checkpoints/horizyn-v1.ckpt
 
 Zenodo:
     DOI: 10.5281/zenodo.20348783
@@ -32,10 +33,22 @@ except ImportError:
 ZENODO_RECORD_ID = 20348783
 ZENODO_API_BASE = f"https://zenodo.org/api/records/{ZENODO_RECORD_ID}"
 
-CHECKPOINT_ZENODO_KEY = "horizyn_v1_0_dev.ckpt"
-CHECKPOINT_LOCAL_NAME = "horizyn-v1.ckpt"
-CHECKPOINT_MD5 = "5b1f938f8b0a82fbe91892a3b4e2bf2c"
-CHECKPOINT_SIZE_MB = 201
+CHECKPOINTS = {
+    "dev": {
+        "zenodo_key": "horizyn_v1_0_dev.ckpt",
+        "local_name": "horizyn_v1_0_dev.ckpt",
+        "md5": "5b1f938f8b0a82fbe91892a3b4e2bf2c",
+        "size_mb": 201,
+        "description": "Development (paper-faithful, train-split only)",
+    },
+    "inf": {
+        "zenodo_key": "horizyn_v1_0_inf.ckpt",
+        "local_name": "horizyn_v1_0_inf.ckpt",
+        "md5": "cf6775b775287462099ae0681485a6bc",
+        "size_mb": 201,
+        "description": "Inference (full training data, for prediction)",
+    },
+}
 
 
 def download_file(url: str, output_path: Path) -> None:
@@ -93,9 +106,35 @@ def verify_checksum(file_path: Path, expected_md5: str) -> bool:
         return False
 
 
+def download_one(ckpt_info: dict, output_dir: Path, force: bool) -> bool:
+    """Download and verify a single checkpoint. Returns True on success."""
+    output_path = output_dir / ckpt_info["local_name"]
+
+    print(f"  {ckpt_info['local_name']}  ({ckpt_info['description']})")
+    print(f"  Size: ~{ckpt_info['size_mb']} MB")
+    print(f"  Output: {output_path}\n")
+
+    if output_path.exists() and not force:
+        print(f"Already exists: {output_path}")
+        print("Use --force to re-download.\n")
+        if verify_checksum(output_path, ckpt_info["md5"]):
+            return True
+        print("Existing file is corrupted. Re-downloading...\n")
+
+    url = f"{ZENODO_API_BASE}/files/{ckpt_info['zenodo_key']}/content"
+    download_file(url, output_path)
+
+    if not verify_checksum(output_path, ckpt_info["md5"]):
+        print("Error: Checksum verification failed!")
+        print("The downloaded file may be corrupted.")
+        return False
+
+    return True
+
+
 def main():
     parser = argparse.ArgumentParser(
-        description="Download Horizyn pre-trained checkpoint from Zenodo",
+        description="Download Horizyn pre-trained checkpoints from Zenodo",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
@@ -106,51 +145,49 @@ def main():
         help="Output directory (default: checkpoints)",
     )
     parser.add_argument(
+        "--only",
+        choices=["dev", "inf"],
+        default=None,
+        help="Download only one checkpoint (default: both)",
+    )
+    parser.add_argument(
         "--force",
         action="store_true",
         help="Force download even if file exists",
     )
 
     args = parser.parse_args()
-
     output_dir = Path(args.output_dir)
-    output_path = output_dir / CHECKPOINT_LOCAL_NAME
+
+    targets = [args.only] if args.only else ["dev", "inf"]
 
     print("=" * 70)
     print("HORIZYN CHECKPOINT DOWNLOAD")
     print("=" * 70)
-    print(f"Checkpoint: {CHECKPOINT_LOCAL_NAME}")
-    print(f"Size: ~{CHECKPOINT_SIZE_MB} MB")
-    print(f"Output: {output_path}")
+    print(f"Record: https://zenodo.org/records/{ZENODO_RECORD_ID}")
+    print(f"Output directory: {output_dir}/")
     print("=" * 70 + "\n")
 
-    if output_path.exists() and not args.force:
-        print(f"Checkpoint already exists: {output_path}")
-        print("Use --force to re-download.\n")
-        if verify_checksum(output_path, CHECKPOINT_MD5):
-            print("✓ Checkpoint ready for evaluation!\n")
-            print("To evaluate, run:")
-            print(f"    python scripts/evaluate.py --checkpoint {output_path}")
-            return
-        else:
-            print("Existing file is corrupted. Re-downloading...\n")
+    failed = []
+    for key in targets:
+        info = CHECKPOINTS[key]
+        print("-" * 70)
+        if not download_one(info, output_dir, args.force):
+            failed.append(key)
 
-    url = f"{ZENODO_API_BASE}/files/{CHECKPOINT_ZENODO_KEY}/content"
-    download_file(url, output_path)
-
-    if not verify_checksum(output_path, CHECKPOINT_MD5):
-        print("Error: Checksum verification failed!")
-        print("The downloaded file may be corrupted.")
+    print("=" * 70)
+    if failed:
+        print(f"FAILED: {', '.join(failed)}")
         sys.exit(1)
 
-    size_mb = output_path.stat().st_size / (1024 * 1024)
-
-    print("=" * 70)
     print("DOWNLOAD COMPLETE")
     print("=" * 70)
-    print(f"✓ Checkpoint ready: {output_path} ({size_mb:.1f} MB)\n")
-    print("To evaluate, run:")
-    print(f"    python scripts/evaluate.py --checkpoint {output_path}")
+    print()
+    print("To evaluate (uses dev checkpoint, matches paper metrics):")
+    print("    python scripts/evaluate.py")
+    print()
+    print("To predict enzymes for a reaction (uses inf checkpoint):")
+    print('    python scripts/predict.py "REACTANTS>>PRODUCTS" --top-k 10')
 
 
 if __name__ == "__main__":

--- a/scripts/download_training_data.py
+++ b/scripts/download_training_data.py
@@ -5,7 +5,7 @@ Download Horizyn SOTA Dataset
 Downloads the SOTA dataset for reproducing the paper results.
 
 Usage:
-    python scripts/download_data.py --output-dir data/sota
+    python scripts/download_training_data.py --output-dir data/sota
 
 Requirements:
     - ~2 GB free disk space for download

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -96,7 +96,7 @@ def evaluate_checkpoint(
 
     # Import required dataset classes
     from horizyn.datasets.base import BaseDataset
-    from horizyn.datasets.collection import MergeDataset, TupleDataset
+    from horizyn.datasets.collection import MergeDataset
     from horizyn.datasets.csv import CSVDataset
     from horizyn.datasets.fingerprints import (
         DRFPFingerprintDataset,
@@ -207,7 +207,9 @@ def evaluate_checkpoint(
     print(f"Screening set size: {num_targets} proteins")
 
     # Create target ID to index mapping
-    target_id_to_idx = {target_id: idx for idx, target_id in enumerate(protein_embeds.keys)}
+    target_id_to_idx = {
+        target_id: idx for idx, target_id in enumerate(protein_embeds.keys)
+    }
 
     # Encode all targets
     print("Encoding all target proteins...")
@@ -216,12 +218,16 @@ def evaluate_checkpoint(
     )
 
     with torch.no_grad():
-        for batch_start in tqdm(range(0, num_targets, batch_size), desc="Encoding targets"):
+        for batch_start in tqdm(
+            range(0, num_targets, batch_size), desc="Encoding targets"
+        ):
             batch_end = min(batch_start + batch_size, num_targets)
             batch_keys = protein_embeds.keys[batch_start:batch_end]
 
             # Get target vectors
-            target_vecs = torch.stack([protein_embeds[k] for k in batch_keys]).to(device)
+            target_vecs = torch.stack([protein_embeds[k] for k in batch_keys]).to(
+                device
+            )
 
             # Encode
             batch_embeds = model.model.target_encoder(target_vecs)
@@ -278,12 +284,22 @@ def evaluate_checkpoint(
             target_idx = torch.tensor(target_indices, dtype=torch.long, device=device)
 
             # Compute metrics
-            metric_results["top_1"].append(top_k_hit_rate(scores, target_idx, k=1).item())
-            metric_results["top_10"].append(top_k_hit_rate(scores, target_idx, k=10).item())
-            metric_results["top_100"].append(top_k_hit_rate(scores, target_idx, k=100).item())
-            metric_results["top_1000"].append(top_k_hit_rate(scores, target_idx, k=1000).item())
+            metric_results["top_1"].append(
+                top_k_hit_rate(scores, target_idx, k=1).item()
+            )
+            metric_results["top_10"].append(
+                top_k_hit_rate(scores, target_idx, k=10).item()
+            )
+            metric_results["top_100"].append(
+                top_k_hit_rate(scores, target_idx, k=100).item()
+            )
+            metric_results["top_1000"].append(
+                top_k_hit_rate(scores, target_idx, k=1000).item()
+            )
             metric_results["r_precision"].append(r_precision(scores, target_idx).item())
-            metric_results["avg_precision"].append(average_precision(scores, target_idx).item())
+            metric_results["avg_precision"].append(
+                average_precision(scores, target_idx).item()
+            )
 
     # Compute mean metrics
     results = {}

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -6,13 +6,13 @@ Evaluates a trained Horizyn checkpoint and computes metrics matching the paper t
 
 Usage:
     python scripts/evaluate.py
-    python scripts/evaluate.py --checkpoint checkpoints/horizyn-v1.ckpt
+    python scripts/evaluate.py --checkpoint checkpoints/horizyn_v1_0_dev.ckpt
 
     # Use custom config
     python scripts/evaluate.py --checkpoint checkpoints/my_model.ckpt --config configs/sota.yaml
 
     # Output as JSON
-    python scripts/evaluate.py --checkpoint checkpoints/horizyn-v1.ckpt --output results.json
+    python scripts/evaluate.py --checkpoint checkpoints/horizyn_v1_0_dev.ckpt --output results.json
 
 Metrics computed:
     - Top-1, Top-10, Top-100, Top-1000 Hit Rates
@@ -20,8 +20,8 @@ Metrics computed:
     - Average Precision (Avg. precision)
 
 Example:
-    # Evaluate the official pre-trained checkpoint
-    python scripts/evaluate.py --checkpoint checkpoints/horizyn-v1.ckpt
+    # Evaluate the official dev checkpoint (paper-faithful, train-split only)
+    python scripts/evaluate.py --checkpoint checkpoints/horizyn_v1_0_dev.ckpt
 """
 
 import argparse
@@ -372,8 +372,8 @@ def main():
     parser.add_argument(
         "--checkpoint",
         type=str,
-        default="checkpoints/horizyn-v1.ckpt",
-        help="Path to checkpoint file (default: checkpoints/horizyn-v1.ckpt)",
+        default="checkpoints/horizyn_v1_0_dev.ckpt",
+        help="Path to checkpoint file (default: checkpoints/horizyn_v1_0_dev.ckpt)",
     )
     parser.add_argument(
         "--config",

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -5,13 +5,14 @@ Horizyn Model Evaluation Script
 Evaluates a trained Horizyn checkpoint and computes metrics matching the paper table.
 
 Usage:
-    python scripts/evaluate.py --checkpoint checkpoints/best_20251214.ckpt
+    python scripts/evaluate.py
+    python scripts/evaluate.py --checkpoint checkpoints/horizyn-v1.ckpt
 
     # Use custom config
-    python scripts/evaluate.py --checkpoint checkpoints/best.ckpt --config configs/sota.yaml
+    python scripts/evaluate.py --checkpoint checkpoints/my_model.ckpt --config configs/sota.yaml
 
     # Output as JSON
-    python scripts/evaluate.py --checkpoint checkpoints/best.ckpt --output results.json
+    python scripts/evaluate.py --checkpoint checkpoints/horizyn-v1.ckpt --output results.json
 
 Metrics computed:
     - Top-1, Top-10, Top-100, Top-1000 Hit Rates
@@ -19,8 +20,8 @@ Metrics computed:
     - Average Precision (Avg. precision)
 
 Example:
-    # Evaluate the SOTA model
-    python scripts/evaluate.py --checkpoint checkpoints/best_20251214/best_20251214.ckpt
+    # Evaluate the official pre-trained checkpoint
+    python scripts/evaluate.py --checkpoint checkpoints/horizyn-v1.ckpt
 """
 
 import argparse
@@ -355,8 +356,8 @@ def main():
     parser.add_argument(
         "--checkpoint",
         type=str,
-        required=True,
-        help="Path to checkpoint file (.ckpt)",
+        default="checkpoints/horizyn-v1.ckpt",
+        help="Path to checkpoint file (default: checkpoints/horizyn-v1.ckpt)",
     )
     parser.add_argument(
         "--config",

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""
+Horizyn Prediction Script
+
+Query the Horizyn model with a reaction SMILES to find matching enzymes.
+
+Usage:
+    python scripts/predict.py "CC(=O)O>>CC(=O)OC" --top-k 10
+
+    # Use a custom checkpoint
+    python scripts/predict.py "CC(=O)O>>CC(=O)OC" --checkpoint checkpoints/my_model.ckpt
+
+    # Output as JSON
+    python scripts/predict.py "CC(=O)O>>CC(=O)OC" --output results.json
+
+    # Bidirectional mode (scores both forward and reverse reaction)
+    python scripts/predict.py "CC(=O)O>>CC(=O)OC" --bidirectional
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import torch
+from tqdm import tqdm
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from horizyn.config import load_config
+from horizyn.datasets.base import BaseDataset
+from horizyn.datasets.collection import MergeDataset
+from horizyn.datasets.fingerprints import DRFPFingerprintDataset, RDKitPlusFingerprintDataset
+from horizyn.datasets.hdf5 import EmbedDataset
+from horizyn.datasets.transform import ConcatTensorTransform
+from horizyn.lightning_module import HorizynLitModule
+
+
+def build_reaction_fingerprint(
+    reaction_smiles: str,
+    config,
+    bidirectional: bool = False,
+) -> tuple[torch.Tensor, list[str]]:
+    """
+    Build concatenated RDKit+ + DRFP fingerprint for a reaction SMILES.
+
+    Returns:
+        Tuple of (fingerprint_tensor, labels) where fingerprint_tensor has shape
+        (N, 2048) with N=1 or N=2 if bidirectional.
+    """
+    keys = ["query_f"]
+    data = [{"reaction_smiles": reaction_smiles}]
+
+    if bidirectional and ">>" in reaction_smiles:
+        parts = reaction_smiles.split(">>")
+        if len(parts) == 2:
+            keys.append("query_r")
+            data.append({"reaction_smiles": f"{parts[1]}>>{parts[0]}"})
+
+    reactions = BaseDataset(keys=keys, array_data=data)
+
+    rdkit_fp = RDKitPlusFingerprintDataset(
+        reaction_dataset=reactions,
+        vec_dim=config.data.get("rdkit_fp_dim", 1024),
+        mol_fp_type="morgan",
+        rxn_fp_type="struct",
+        use_chirality=True,
+        standardize=config.data.get("standardize_reactions", True),
+        standardize_hypervalent=config.data.get("standardize_hypervalent", True),
+        standardize_remove_hs=config.data.get("standardize_remove_hs", True),
+        standardize_kekulize=config.data.get("standardize_kekulize", False),
+        standardize_uncharge=config.data.get("standardize_uncharge", True),
+        standardize_metals=config.data.get("standardize_metals", True),
+    )
+
+    drfp_fp = DRFPFingerprintDataset(
+        reaction_dataset=reactions,
+        vec_dim=config.data.get("drfp_dim", 1024),
+        radius=3,
+        rings=True,
+        standardize=config.data.get("standardize_reactions", True),
+        standardize_hypervalent=config.data.get("standardize_hypervalent", True),
+        standardize_remove_hs=config.data.get("standardize_remove_hs", True),
+        standardize_kekulize=config.data.get("standardize_kekulize", False),
+        standardize_uncharge=config.data.get("standardize_uncharge", True),
+        standardize_metals=config.data.get("standardize_metals", True),
+    )
+
+    merged = MergeDataset(
+        datasets={"rdkit": rdkit_fp, "drfp": drfp_fp},
+        add_prefix=False,
+    )
+    merged.append_transforms(ConcatTensorTransform(labels=["rdkit", "drfp"], dim=0))
+
+    fps = torch.stack([merged[k] for k in keys])
+    return fps, keys
+
+
+def predict(
+    reaction_smiles: str,
+    checkpoint_path: str = "checkpoints/horizyn-v1.ckpt",
+    config_path: str = "configs/sota.yaml",
+    device: str = "cuda",
+    top_k: int = 10,
+    batch_size: int = 512,
+    bidirectional: bool = False,
+) -> dict:
+    """
+    Query the model with a reaction SMILES and return top-K protein matches.
+    """
+    config = load_config(config_path)
+
+    print(f"Loading checkpoint: {checkpoint_path}")
+    model = HorizynLitModule.load_from_checkpoint(checkpoint_path, map_location=device)
+    model.eval()
+    model.to(device)
+
+    print("Generating reaction fingerprints...")
+    query_fps, query_labels = build_reaction_fingerprint(
+        reaction_smiles, config, bidirectional=bidirectional
+    )
+    query_fps = query_fps.to(device)
+
+    print("Loading protein embeddings...")
+    protein_embeds = EmbedDataset(
+        file_path=config.data.protein_embeds_path,
+        in_memory=True,
+    )
+    num_targets = len(protein_embeds)
+    print(f"  {num_targets} proteins in screening set")
+
+    print("Encoding proteins...")
+    target_dim = model.model.target_encoder.output_dim
+    target_embeds = torch.zeros(num_targets, target_dim, device=device)
+
+    with torch.no_grad():
+        for start in tqdm(range(0, num_targets, batch_size), desc="Encoding"):
+            end = min(start + batch_size, num_targets)
+            batch_keys = protein_embeds.keys[start:end]
+            vecs = torch.stack([protein_embeds[k] for k in batch_keys]).to(device)
+            target_embeds[start:end] = model.model.target_encoder(vecs)
+
+    print("Encoding reaction and ranking proteins...")
+    with torch.no_grad():
+        query_embeds = model.model.query_encoder(query_fps)
+
+        # Average embeddings if bidirectional
+        if query_embeds.shape[0] > 1:
+            query_embed = query_embeds.mean(dim=0, keepdim=True)
+        else:
+            query_embed = query_embeds
+
+        scores = torch.matmul(query_embed, target_embeds.T).squeeze(0)
+
+    top_scores, top_indices = torch.topk(scores, k=min(top_k, num_targets))
+
+    results = []
+    for score, idx in zip(top_scores.cpu().tolist(), top_indices.cpu().tolist()):
+        results.append({
+            "protein_id": protein_embeds.keys[idx],
+            "score": round(score, 6),
+            "rank": len(results) + 1,
+        })
+
+    return {
+        "reaction_smiles": reaction_smiles,
+        "bidirectional": bidirectional,
+        "num_proteins_screened": num_targets,
+        "top_k": top_k,
+        "results": results,
+    }
+
+
+def format_results(results: dict) -> str:
+    lines = []
+    lines.append("=" * 70)
+    lines.append("HORIZYN PREDICTION RESULTS")
+    lines.append("=" * 70)
+    lines.append(f"Reaction: {results['reaction_smiles']}")
+    lines.append(f"Bidirectional: {results['bidirectional']}")
+    lines.append(f"Proteins screened: {results['num_proteins_screened']}")
+    lines.append("")
+    lines.append(f"{'Rank':<6} {'Protein ID':<20} {'Score':<12}")
+    lines.append("-" * 38)
+
+    for hit in results["results"]:
+        lines.append(f"{hit['rank']:<6} {hit['protein_id']:<20} {hit['score']:<12.6f}")
+
+    lines.append("=" * 70)
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Query Horizyn with a reaction SMILES to find matching enzymes",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "reaction_smiles",
+        type=str,
+        help="Reaction SMILES string (e.g. 'reactants>>products')",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=str,
+        default="checkpoints/horizyn-v1.ckpt",
+        help="Path to checkpoint (default: checkpoints/horizyn-v1.ckpt)",
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="configs/sota.yaml",
+        help="Path to config file (default: configs/sota.yaml)",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=10,
+        help="Number of top matches to return (default: 10)",
+    )
+    parser.add_argument(
+        "--bidirectional",
+        action="store_true",
+        help="Score both forward and reverse reaction directions",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Save results as JSON to this path",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        help="Device (default: cuda if available)",
+    )
+
+    args = parser.parse_args()
+
+    if not Path(args.checkpoint).exists():
+        print(f"Error: Checkpoint not found: {args.checkpoint}")
+        print("Download it with: python scripts/download_checkpoint.py")
+        sys.exit(1)
+
+    if not Path(args.config).exists():
+        print(f"Error: Config not found: {args.config}")
+        sys.exit(1)
+
+    results = predict(
+        reaction_smiles=args.reaction_smiles,
+        checkpoint_path=args.checkpoint,
+        config_path=args.config,
+        device=args.device,
+        top_k=args.top_k,
+        bidirectional=args.bidirectional,
+    )
+
+    print("\n" + format_results(results))
+
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(results, f, indent=2)
+        print(f"\nResults saved to: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -5,16 +5,17 @@ Horizyn Prediction Script
 Query the Horizyn model with a reaction SMILES to find matching enzymes.
 
 Usage:
-    python scripts/predict.py "CC(=O)O>>CC(=O)OC" --top-k 10
+    # Example: ADP + H2O -> AMP + phosphate
+    python scripts/predict.py "NC1=NC=NC2=C1N=CN2[C@@H]1O[C@H](COP(=O)([O-])[O-])[C@@H](OP(=O)([O-])[O-])[C@H]1O.[H]O[H]>>NC1=NC=NC2=C1N=CN2[C@@H]1O[C@H](COP(=O)([O-])[O-])[C@@H](O)[C@H]1O.O=P([O-])([O-])O" --top-k 10
 
     # Use a custom checkpoint
-    python scripts/predict.py "CC(=O)O>>CC(=O)OC" --checkpoint checkpoints/my_model.ckpt
+    python scripts/predict.py "REACTANT_SMILES>>PRODUCT_SMILES" --checkpoint checkpoints/my_model.ckpt
 
     # Output as JSON
-    python scripts/predict.py "CC(=O)O>>CC(=O)OC" --output results.json
+    python scripts/predict.py "REACTANT_SMILES>>PRODUCT_SMILES" --output results.json
 
     # Bidirectional mode (scores both forward and reverse reaction)
-    python scripts/predict.py "CC(=O)O>>CC(=O)OC" --bidirectional
+    python scripts/predict.py "REACTANT_SMILES>>PRODUCT_SMILES" --bidirectional
 """
 
 import argparse

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -100,7 +100,7 @@ def build_reaction_fingerprint(
 
 def predict(
     reaction_smiles: str,
-    checkpoint_path: str = "checkpoints/horizyn-v1.ckpt",
+    checkpoint_path: str = "checkpoints/horizyn_v1_0_inf.ckpt",
     config_path: str = "configs/sota.yaml",
     device: str = "cuda",
     top_k: int = 10,
@@ -206,8 +206,8 @@ def main():
     parser.add_argument(
         "--checkpoint",
         type=str,
-        default="checkpoints/horizyn-v1.ckpt",
-        help="Path to checkpoint (default: checkpoints/horizyn-v1.ckpt)",
+        default="checkpoints/horizyn_v1_0_inf.ckpt",
+        help="Path to checkpoint (default: checkpoints/horizyn_v1_0_inf.ckpt)",
     )
     parser.add_argument(
         "--config",

--- a/tests/integration/test_sota.py
+++ b/tests/integration/test_sota.py
@@ -34,7 +34,7 @@ def check_sota_data():
         if not filepath.exists():
             pytest.skip(
                 f"SOTA data not found: {filename}. "
-                "Run 'python scripts/download_data.py' to download."
+                "Run 'python scripts/download_training_data.py' to download."
             )
 
 

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -66,9 +66,8 @@ class TestDownloadScript:
             # Check required fields
             assert "name" in config
             assert "version" in config
-            assert "url" in config
+            assert "doi" in config
             assert "size_gb" in config
-            assert "checksum" in config
             assert "files" in config
 
             # Check files list
@@ -138,7 +137,7 @@ class TestDownloadScript:
             sys.path.pop(0)
 
     def test_verify_checksum_placeholder(self, tmp_path):
-        """Test that placeholder checksum is skipped."""
+        """Test that placeholder checksum fails verification."""
         import sys
         from pathlib import Path
 
@@ -155,9 +154,9 @@ class TestDownloadScript:
             # Use placeholder checksum
             placeholder_checksum = "sha256:XXXXX"
 
-            # Verify (should skip and return True)
+            # Verify (no skip logic — placeholder fails like any wrong hash)
             result = download_training_data.verify_checksum(test_file, placeholder_checksum)
-            assert result is True
+            assert result is False
 
         finally:
             sys.path.pop(0)
@@ -226,8 +225,8 @@ class TestDownloadScript:
         assert "--force" in result.stdout
 
     @patch("sys.argv", ["download_training_data.py", "--output-dir", "data/"])
-    def test_download_with_placeholder_url(self):
-        """Test that placeholder URL produces helpful error."""
+    def test_download_with_existing_files_skips(self):
+        """Test that download is skipped when all files exist."""
         import sys
         from pathlib import Path
 
@@ -237,11 +236,15 @@ class TestDownloadScript:
         try:
             import download_training_data
 
-            # Should exit with error for placeholder URL
-            with pytest.raises(SystemExit) as exc_info:
-                download_training_data.main()
-
-            assert exc_info.value.code == 1
+            with patch("download_training_data.verify_dataset_files", return_value=True):
+                with patch("download_training_data.Path.exists", return_value=True):
+                    with patch("download_training_data.download_file") as mock_dl:
+                        try:
+                            download_training_data.main()
+                        except SystemExit:
+                            pass
+                        # When files exist, download should not be called
+                        mock_dl.assert_not_called()
 
         finally:
             sys.path.pop(0)

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -1,5 +1,5 @@
 """
-Unit tests for the scripts/download_data.py script.
+Unit tests for the scripts/download_training_data.py script.
 """
 
 import hashlib
@@ -11,31 +11,31 @@ import pytest
 
 
 class TestDownloadScript:
-    """Tests for the download_data.py script."""
+    """Tests for the download_training_data.py script."""
 
     def test_download_script_exists(self):
-        """Test that download_data.py exists."""
-        download_script = Path("scripts/download_data.py")
-        assert download_script.exists(), "scripts/download_data.py not found"
-        assert download_script.is_file(), "scripts/download_data.py is not a file"
+        """Test that download_training_data.py exists."""
+        download_script = Path("scripts/download_training_data.py")
+        assert download_script.exists(), "scripts/download_training_data.py not found"
+        assert download_script.is_file(), "scripts/download_training_data.py is not a file"
 
     def test_download_script_has_shebang(self):
-        """Test that download_data.py has proper shebang."""
-        download_script = Path("scripts/download_data.py")
+        """Test that download_training_data.py has proper shebang."""
+        download_script = Path("scripts/download_training_data.py")
         with open(download_script, "r") as f:
             first_line = f.readline()
         assert first_line.startswith("#!/usr/bin/env python"), "Missing or incorrect shebang"
 
     def test_download_script_has_docstring(self):
-        """Test that download_data.py has a docstring."""
-        download_script = Path("scripts/download_data.py")
+        """Test that download_training_data.py has a docstring."""
+        download_script = Path("scripts/download_training_data.py")
         with open(download_script, "r") as f:
             content = f.read()
         assert '"""' in content, "Missing docstring"
         assert "Usage:" in content, "Missing usage documentation"
 
     def test_download_script_imports(self):
-        """Test that download_data.py can be imported."""
+        """Test that download_training_data.py can be imported."""
         # Add scripts/ to path
         import sys
         from pathlib import Path
@@ -44,7 +44,7 @@ class TestDownloadScript:
         sys.path.insert(0, str(scripts_dir))
 
         try:
-            import download_data  # noqa: F401
+            import download_training_data  # noqa: F401
 
             # Should not raise ImportError
         finally:
@@ -59,9 +59,9 @@ class TestDownloadScript:
         sys.path.insert(0, str(scripts_dir))
 
         try:
-            import download_data
+            import download_training_data
 
-            config = download_data.DATASET_CONFIG
+            config = download_training_data.DATASET_CONFIG
 
             # Check required fields
             assert "name" in config
@@ -92,7 +92,7 @@ class TestDownloadScript:
         sys.path.insert(0, str(scripts_dir))
 
         try:
-            import download_data
+            import download_training_data
 
             # Create test file
             test_file = tmp_path / "test.txt"
@@ -104,7 +104,7 @@ class TestDownloadScript:
             checksum = f"sha256:{expected_hash}"
 
             # Verify
-            result = download_data.verify_checksum(test_file, checksum)
+            result = download_training_data.verify_checksum(test_file, checksum)
             assert result is True
 
         finally:
@@ -119,7 +119,7 @@ class TestDownloadScript:
         sys.path.insert(0, str(scripts_dir))
 
         try:
-            import download_data
+            import download_training_data
 
             # Create test file
             test_file = tmp_path / "test.txt"
@@ -131,7 +131,7 @@ class TestDownloadScript:
             )
 
             # Verify
-            result = download_data.verify_checksum(test_file, wrong_checksum)
+            result = download_training_data.verify_checksum(test_file, wrong_checksum)
             assert result is False
 
         finally:
@@ -146,7 +146,7 @@ class TestDownloadScript:
         sys.path.insert(0, str(scripts_dir))
 
         try:
-            import download_data
+            import download_training_data
 
             # Create test file
             test_file = tmp_path / "test.txt"
@@ -156,7 +156,7 @@ class TestDownloadScript:
             placeholder_checksum = "sha256:XXXXX"
 
             # Verify (should skip and return True)
-            result = download_data.verify_checksum(test_file, placeholder_checksum)
+            result = download_training_data.verify_checksum(test_file, placeholder_checksum)
             assert result is True
 
         finally:
@@ -171,7 +171,7 @@ class TestDownloadScript:
         sys.path.insert(0, str(scripts_dir))
 
         try:
-            import download_data
+            import download_training_data
 
             # Create test files
             expected_files = ["file1.db", "file2.db", "file3.h5"]
@@ -179,7 +179,7 @@ class TestDownloadScript:
                 (tmp_path / filename).write_text("test content")
 
             # Verify
-            result = download_data.verify_dataset_files(tmp_path, expected_files)
+            result = download_training_data.verify_dataset_files(tmp_path, expected_files)
             assert result is True
 
         finally:
@@ -194,7 +194,7 @@ class TestDownloadScript:
         sys.path.insert(0, str(scripts_dir))
 
         try:
-            import download_data
+            import download_training_data
 
             # Create only some files
             expected_files = ["file1.db", "file2.db", "file3.h5"]
@@ -202,19 +202,19 @@ class TestDownloadScript:
             # file2.db and file3.h5 are missing
 
             # Verify
-            result = download_data.verify_dataset_files(tmp_path, expected_files)
+            result = download_training_data.verify_dataset_files(tmp_path, expected_files)
             assert result is False
 
         finally:
             sys.path.pop(0)
 
-    @patch("sys.argv", ["download_data.py", "--help"])
+    @patch("sys.argv", ["download_training_data.py", "--help"])
     def test_download_help_message(self):
         """Test that --help produces usage information."""
         import subprocess
 
         result = subprocess.run(
-            [sys.executable, "scripts/download_data.py", "--help"],
+            [sys.executable, "scripts/download_training_data.py", "--help"],
             capture_output=True,
             text=True,
         )
@@ -225,7 +225,7 @@ class TestDownloadScript:
         assert "--skip_checksum" in result.stdout
         assert "--force" in result.stdout
 
-    @patch("sys.argv", ["download_data.py", "--output-dir", "data/"])
+    @patch("sys.argv", ["download_training_data.py", "--output-dir", "data/"])
     def test_download_with_placeholder_url(self):
         """Test that placeholder URL produces helpful error."""
         import sys
@@ -235,11 +235,11 @@ class TestDownloadScript:
         sys.path.insert(0, str(scripts_dir))
 
         try:
-            import download_data
+            import download_training_data
 
             # Should exit with error for placeholder URL
             with pytest.raises(SystemExit) as exc_info:
-                download_data.main()
+                download_training_data.main()
 
             assert exc_info.value.code == 1
 
@@ -255,9 +255,9 @@ class TestDownloadScript:
         sys.path.insert(0, str(scripts_dir))
 
         try:
-            import download_data
+            import download_training_data
 
-            expected_files = download_data.DATASET_CONFIG["files"]
+            expected_files = download_training_data.DATASET_CONFIG["files"]
 
             # These files are required by HorizynDataModule
             required_files = [

--- a/tests/unit/test_download_training_data.py
+++ b/tests/unit/test_download_training_data.py
@@ -2,7 +2,6 @@
 
 import hashlib
 import sys
-import tarfile
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
@@ -13,8 +12,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from download_training_data import (
     DATASET_CONFIG,
+    decompress_gz,
     download_file,
-    extract_archive,
     verify_checksum,
     verify_dataset_files,
 )
@@ -125,13 +124,12 @@ class TestVerifyChecksum:
 
         assert not verify_checksum(test_file, "md5:wronghash123")
 
-    def test_checksum_placeholder(self, tmp_path):
-        """Test checksum verification skips placeholder values."""
+    def test_checksum_placeholder_fails(self, tmp_path):
+        """Test that placeholder checksums fail verification (no skip logic)."""
         test_file = tmp_path / "test.txt"
         test_file.write_bytes(b"test content")
 
-        # Should return True and skip verification
-        assert verify_checksum(test_file, "md5:XXXXX")
+        assert not verify_checksum(test_file, "md5:XXXXX")
 
     def test_unsupported_algorithm(self, tmp_path):
         """Test unsupported hash algorithm raises error."""
@@ -142,50 +140,41 @@ class TestVerifyChecksum:
             verify_checksum(test_file, "sha512:somehash")
 
 
-class TestExtractArchive:
-    """Tests for extract_archive function."""
+class TestDecompressGz:
+    """Tests for decompress_gz function."""
 
-    def test_extract_tar_gz(self, tmp_path):
-        """Test extraction of tar.gz archive."""
-        # Create a test archive
-        archive_path = tmp_path / "test.tar.gz"
-        extract_dir = tmp_path / "extracted"
-        extract_dir.mkdir()
+    def test_decompress_gz_file(self, tmp_path):
+        """Test decompression of a .gz file."""
+        import gzip
 
-        # Create test content
-        test_file = tmp_path / "test.txt"
-        test_file.write_text("test content")
+        # Create a test .gz file
+        gz_path = tmp_path / "test.h5.gz"
+        out_path = tmp_path / "test.h5"
+        original_content = b"test content for decompression"
 
-        # Create archive
-        with tarfile.open(archive_path, "w:gz") as tar:
-            tar.add(test_file, arcname="test.txt")
+        with gzip.open(gz_path, "wb") as f:
+            f.write(original_content)
 
-        # Extract
-        with patch("download_training_data.tqdm", side_effect=lambda x, **kwargs: x):
-            extract_archive(archive_path, extract_dir)
+        decompress_gz(gz_path, out_path)
 
-        # Verify extraction
-        extracted_file = extract_dir / "test.txt"
-        assert extracted_file.exists()
-        assert extracted_file.read_text() == "test content"
+        assert out_path.exists()
+        assert out_path.read_bytes() == original_content
+        assert not gz_path.exists()  # .gz file is removed after decompression
 
-    def test_extract_creates_directory(self, tmp_path):
-        """Test extraction creates output directory if needed."""
-        archive_path = tmp_path / "test.tar.gz"
-        extract_dir = tmp_path / "new_dir" / "extracted"
+    def test_decompress_creates_output(self, tmp_path):
+        """Test decompression creates the output file."""
+        import gzip
 
-        # Create minimal archive
-        test_file = tmp_path / "test.txt"
-        test_file.write_text("test")
-        with tarfile.open(archive_path, "w:gz") as tar:
-            tar.add(test_file, arcname="test.txt")
+        gz_path = tmp_path / "data.csv.gz"
+        out_path = tmp_path / "data.csv"
 
-        # Extract (should create directory)
-        with patch("download_training_data.tqdm", side_effect=lambda x, **kwargs: x):
-            extract_archive(archive_path, extract_dir)
+        with gzip.open(gz_path, "wb") as f:
+            f.write(b"col1,col2\na,b\n")
 
-        assert extract_dir.exists()
-        assert (extract_dir / "test.txt").exists()
+        decompress_gz(gz_path, out_path)
+
+        assert out_path.exists()
+        assert out_path.read_text() == "col1,col2\na,b\n"
 
 
 class TestVerifyDatasetFiles:
@@ -222,8 +211,8 @@ class TestDatasetConfig:
         """Test config contains all required fields."""
         assert "name" in DATASET_CONFIG
         assert "version" in DATASET_CONFIG
-        assert "url" in DATASET_CONFIG
-        assert "checksum" in DATASET_CONFIG
+        assert "doi" in DATASET_CONFIG
+        assert "size_gb" in DATASET_CONFIG
         assert "files" in DATASET_CONFIG
         assert "file_checksums" in DATASET_CONFIG
 
@@ -233,9 +222,9 @@ class TestDatasetConfig:
         checksum_files = set(DATASET_CONFIG["file_checksums"].keys())
         assert expected_files == checksum_files
 
-    def test_config_has_five_files(self):
-        """Test config specifies exactly 5 expected files."""
-        assert len(DATASET_CONFIG["files"]) == 5
+    def test_config_has_six_files(self):
+        """Test config specifies exactly 6 expected files."""
+        assert len(DATASET_CONFIG["files"]) == 6
 
     def test_config_file_names(self):
         """Test config has correct file names."""
@@ -245,16 +234,15 @@ class TestDatasetConfig:
             "train_rxns.csv",
             "test_rxns.csv",
             "prots_t5.h5",
+            "prots.fasta",
         ]
         assert set(DATASET_CONFIG["files"]) == set(expected)
 
     def test_config_checksums_are_valid_or_placeholder(self):
         """Test all individual checksums are valid MD5 format or placeholders."""
         for filename, checksum in DATASET_CONFIG["file_checksums"].items():
-            # Allow placeholder values during development
             if checksum == "XXXXX":
                 continue
-            # MD5 hashes are 32 hex characters
             assert len(checksum) == 32, f"Invalid MD5 for {filename}"
             assert all(c in "0123456789abcdef" for c in checksum), f"Invalid MD5 hex for {filename}"
 
@@ -277,16 +265,6 @@ class TestMainFunction:
 
                     # Should not attempt download
                     mock_download.assert_not_called()
-
-    def test_placeholder_url_exits(self, tmp_path):
-        """Test exits gracefully when URL is placeholder."""
-        with patch("sys.argv", ["download_training_data.py", "--output-dir", str(tmp_path), "--force"]):
-            with pytest.raises(SystemExit) as exc_info:
-                from download_training_data import main
-
-                main()
-
-            assert exc_info.value.code == 1
 
     def test_default_output_directory(self):
         """Test default output directory is data/sota."""

--- a/tests/unit/test_download_training_data.py
+++ b/tests/unit/test_download_training_data.py
@@ -1,4 +1,4 @@
-"""Tests for scripts/download_data.py"""
+"""Tests for scripts/download_training_data.py"""
 
 import hashlib
 import sys
@@ -11,7 +11,7 @@ import pytest
 # Add scripts to path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
-from download_data import (
+from download_training_data import (
     DATASET_CONFIG,
     download_file,
     extract_archive,
@@ -37,8 +37,8 @@ class TestDownloadFile:
         mock_progress = Mock()
         mock_progress.n = len(test_content)
 
-        with patch("download_data.requests.get", return_value=mock_response):
-            with patch("download_data.tqdm", return_value=mock_progress):
+        with patch("download_training_data.requests.get", return_value=mock_response):
+            with patch("download_training_data.tqdm", return_value=mock_progress):
                 download_file("https://example.com/file.tar.gz", output_file)
 
         assert output_file.exists()
@@ -57,8 +57,8 @@ class TestDownloadFile:
         mock_progress = Mock()
         mock_progress.n = len(test_content)
 
-        with patch("download_data.requests.get", return_value=mock_response):
-            with patch("download_data.tqdm", return_value=mock_progress):
+        with patch("download_training_data.requests.get", return_value=mock_response):
+            with patch("download_training_data.tqdm", return_value=mock_progress):
                 download_file("https://example.com/file.tar.gz", output_file)
 
         assert output_file.exists()
@@ -71,7 +71,7 @@ class TestDownloadFile:
         import requests
 
         with patch(
-            "download_data.requests.get",
+            "download_training_data.requests.get",
             side_effect=requests.exceptions.RequestException("Network error"),
         ):
             with pytest.raises(RuntimeError, match="Download failed"):
@@ -86,8 +86,8 @@ class TestDownloadFile:
         mock_response.headers = {"content-length": "1000"}  # Expected size larger than actual
         mock_response.iter_content = Mock(return_value=[test_content])
 
-        with patch("download_data.requests.get", return_value=mock_response):
-            with patch("download_data.tqdm") as mock_tqdm:
+        with patch("download_training_data.requests.get", return_value=mock_response):
+            with patch("download_training_data.tqdm") as mock_tqdm:
                 # Mock progress bar with wrong final size
                 mock_progress = Mock()
                 mock_progress.n = len(test_content)  # Actual size
@@ -161,7 +161,7 @@ class TestExtractArchive:
             tar.add(test_file, arcname="test.txt")
 
         # Extract
-        with patch("download_data.tqdm", side_effect=lambda x, **kwargs: x):
+        with patch("download_training_data.tqdm", side_effect=lambda x, **kwargs: x):
             extract_archive(archive_path, extract_dir)
 
         # Verify extraction
@@ -181,7 +181,7 @@ class TestExtractArchive:
             tar.add(test_file, arcname="test.txt")
 
         # Extract (should create directory)
-        with patch("download_data.tqdm", side_effect=lambda x, **kwargs: x):
+        with patch("download_training_data.tqdm", side_effect=lambda x, **kwargs: x):
             extract_archive(archive_path, extract_dir)
 
         assert extract_dir.exists()
@@ -268,10 +268,10 @@ class TestMainFunction:
         for filename in DATASET_CONFIG["files"]:
             (tmp_path / filename).write_bytes(b"existing")
 
-        with patch("sys.argv", ["download_data.py", "--output-dir", str(tmp_path)]):
-            with patch("download_data.verify_dataset_files", return_value=True):
-                with patch("download_data.download_file") as mock_download:
-                    from download_data import main
+        with patch("sys.argv", ["download_training_data.py", "--output-dir", str(tmp_path)]):
+            with patch("download_training_data.verify_dataset_files", return_value=True):
+                with patch("download_training_data.download_file") as mock_download:
+                    from download_training_data import main
 
                     main()
 
@@ -280,9 +280,9 @@ class TestMainFunction:
 
     def test_placeholder_url_exits(self, tmp_path):
         """Test exits gracefully when URL is placeholder."""
-        with patch("sys.argv", ["download_data.py", "--output-dir", str(tmp_path), "--force"]):
+        with patch("sys.argv", ["download_training_data.py", "--output-dir", str(tmp_path), "--force"]):
             with pytest.raises(SystemExit) as exc_info:
-                from download_data import main
+                from download_training_data import main
 
                 main()
 
@@ -290,11 +290,11 @@ class TestMainFunction:
 
     def test_default_output_directory(self):
         """Test default output directory is data/sota."""
-        with patch("sys.argv", ["download_data.py"]):
-            with patch("download_data.Path.mkdir"):
-                with patch("download_data.verify_dataset_files", return_value=True):
+        with patch("sys.argv", ["download_training_data.py"]):
+            with patch("download_training_data.Path.mkdir"):
+                with patch("download_training_data.verify_dataset_files", return_value=True):
                     with patch("sys.exit"):  # Prevent actual exit
-                        from download_data import main
+                        from download_training_data import main
 
                         try:
                             main()

--- a/train.py
+++ b/train.py
@@ -14,7 +14,7 @@ Usage:
     python train.py --config configs/sota.yaml --seed 123
 
 Requirements:
-    - Data must be downloaded first (see scripts/download_data.py)
+    - Data must be downloaded first (see scripts/download_training_data.py)
     - Requires ~16GB RAM (all data loaded into memory)
     - Requires single GPU with 16GB+ VRAM
 
@@ -138,7 +138,7 @@ def main():
         print(f"\nError: Data file not found")
         print(f"{e}")
         print("\nPlease download the dataset first:")
-        print("    python scripts/download_data.py")
+        print("    python scripts/download_training_data.py")
         sys.exit(1)
     except Exception as e:
         print(f"\nError initializing data module: {e}")


### PR DESCRIPTION
## Summary

- Fix the README quick-start (`uv run` prefix on every script, sane install → data → checkpoint → evaluate ordering, valid example SMILES).
- Add `scripts/download_checkpoint.py` to fetch both pre-trained checkpoints from Zenodo record [20348783](https://zenodo.org/records/20348783):
  - `horizyn_v1_0_dev.ckpt` — paper-faithful (train split only), for evaluation
  - `horizyn_v1_0_inf.ckpt` — full training data, for prediction
- `evaluate.py` defaults to the dev checkpoint; `predict.py` defaults to the inf checkpoint.
- Rename `scripts/download_data.py` → `scripts/download_training_data.py` (distinct from the checkpoint downloader); update tests, configs, manual, train.py.
- Add `scripts/predict.py` (reaction SMILES → ranked proteins) with a real, end-to-end-tested example reaction.
- Update citation to published PNAS reference.
- Fix unit tests to match the current download script API.
- Add "Run Tests" section to README.

## Zenodo status

✅ Both checkpoints are live at [zenodo.org/records/20348783](https://zenodo.org/records/20348783) (v2). Filename typo fixed, all tensor files present, md5 verified for both dev and inf.

## Verification

- Stripped dev ckpt loads via `HorizynLitModule.load_from_checkpoint`.
- `evaluate.py` on the bundled 216K screening set: top-1 32.4%, top-10 53.9%, R-precision 33.3% — matches the paper.
- `predict.py --bidirectional --top-k 500` on Rh_10112 (cystathionine β-synthase, train reaction): top-1 0.957, all 13 known enzymes within rank 13.
- Unit tests pass (34/34).

## Test plan

- [x] `python scripts/download_checkpoint.py` from a clean clone — both checkpoints download, md5 verified.
- [x] `uv run python scripts/evaluate.py` produces top-1 ≈ 32.4%.
- [x] `uv run python scripts/predict.py` on the README example reaction returns high-confidence rankings.
- [x] `uv run pytest` passes.