### PR TITLE
docs: use a balanced example reaction, document cofactor filter matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,14 @@ curl -X POST https://api.horizyn1.dayhofflabs.com/keys/confirm \
   -d '{"email": "you@example.com", "code": "123456", "name": "my-project"}'
 ```
 
-Then query a reaction:
+Then query a reaction. Use balanced reactions — the example below is GabT
+transamination of 2-oxoglutarate using 6-aminohexanoate:
 
 ```bash
 curl -X POST https://api.horizyn1.dayhofflabs.com/query/reaction \
   -H "Authorization: Bearer $HORIZYN_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"smiles": "CCO>>CC=O"}'
+  -d '{"smiles": "[NH3+]CCCCCC([O-])=O.[O-]C(=O)CCC(=O)C([O-])=O>>[O-]C(=O)CCCCC=O.[NH3+][C@@H](CCC([O-])=O)C([O-])=O"}'
 ```
 
 Full documentation — every endpoint, request options, filtering, clustering,

--- a/horizyn-api-guide.md
+++ b/horizyn-api-guide.md
@@ -30,6 +30,7 @@ a client in your language of choice.
 3. [Authenticate](#3-authenticate)
 4. [Search for enzymes by reaction](#4-search-for-enzymes-by-reaction)
 5. [List available screening sets](#5-list-available-screening-sets)
+5a. [List available cofactors](#5a-list-available-cofactors)
 6. [Validate SMILES before querying](#6-validate-smiles-before-querying)
 7. [Look up an enzyme](#7-look-up-an-enzyme)
 8. [Rate limits](#8-rate-limits)
@@ -128,11 +129,18 @@ returns ranked enzyme candidates.
 
 **Minimal request:**
 
+The reaction below is GabT transamination of 2-oxoglutarate using
+6-aminohexanoate — a real, atom- and charge-balanced reaction. Balance your
+reactions: include cosubstrates and cofactor-derived products rather than writing
+only the transformation you care about. Unbalanced input still returns results,
+but the closer your SMILES is to the full biochemical reaction, the better the
+matches.
+
 ```bash
 curl -X POST https://api.horizyn1.dayhofflabs.com/query/reaction \
   -H "Authorization: Bearer $HORIZYN_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"smiles": "CCO>>CC=O"}'
+  -d '{"smiles": "[NH3+]CCCCCC([O-])=O.[O-]C(=O)CCC(=O)C([O-])=O>>[O-]C(=O)CCCCC=O.[NH3+][C@@H](CCC([O-])=O)C([O-])=O"}'
 ```
 
 ### Request fields
@@ -149,19 +157,26 @@ curl -X POST https://api.horizyn1.dayhofflabs.com/query/reaction \
 | `fetch_metadata` | bool | `true` | Attach enzyme annotations (name, organism, EC, etc.) to results |
 | `ec_include` / `ec_exclude` | list[string] | `null` | Keep / drop results by EC number prefix |
 | `tc_include` / `tc_exclude` | list[string] | `null` | Keep / drop results by transporter classification |
-| `cofactor_include` / `cofactor_exclude` | list[string] | `null` | Keep / drop results by cofactor |
+| `cofactor_include` / `cofactor_exclude` | list[string] | `null` | Keep / drop results by cofactor. Accepts acronyms (`"PLP"`, `"SAM"`, `"TPP"`), element names (`"zinc"`), and ChEBI spellings; case-insensitive |
 | `min_length` / `max_length` | int | `null` | Keep results within a sequence-length range |
 
 Note that `top_k` is applied *before* filtering, so aggressive filters combined
 with a small `top_k` can return very few rows. Raise `top_k` if you are filtering
 hard.
 
-Cofactor names are matched as case-sensitive *substrings* of the annotation, which
-uses ChEBI-style spellings — `"NAD(+)"`, `"NADH"`, `"NADPH"`, `"Zn(2+)"`. So
-`"NAD"` matches all of `NAD(+)`, `NADH`, `NADP(+)` and `NADPH`, whereas `"NAD+"`
-matches nothing at all. Read the `cofactors` values off a few unfiltered results
-before relying on a cofactor filter. EC and transporter-class filters match by
-prefix instead.
+Cofactor filters accept common acronyms and names as well as the ChEBI spellings
+used in the annotations, and matching is case-insensitive. All of `"PLP"`,
+`"pyridoxal phosphate"` and `"pyridoxal 5'-phosphate"` select the same
+PLP-dependent enzymes; `"SAM"`, `"TPP"`, `"PQQ"`, `"B12"`, `"zinc"` and `"Heme"`
+work too. A term matching no cofactor in the screening set is reported in the
+response's `warnings` rather than silently returning nothing. Call
+`GET /cofactors` to list every annotated cofactor with enzyme counts. EC and
+transporter-class filters match by prefix instead.
+
+Two caveats specific to cofactor filters: annotations are sparse — roughly two
+thirds of enzymes have no cofactor annotation at all, and a `cofactor_include`
+filter drops every one of them — and filtering happens after the `top_k` search,
+so pair a narrow cofactor filter with a large `top_k`.
 
 ### Response (flat list)
 
@@ -169,16 +184,16 @@ prefix instead.
 {
   "results": [
     {
-      "id": "P12345",
-      "score": 0.87,
-      "name": "Alcohol dehydrogenase",
-      "organism": "Escherichia coli",
-      "ec_numbers": ["1.1.1.1"],
-      "cofactors": ["NAD(+)"],
-      "expression_score": 0.72,
-      "tc_numbers": null,
-      "organism_lineage": ["Bacteria", "Proteobacteria"],
-      "length": 375
+      "id": "P22256",
+      "score": 0.915,
+      "name": "4-aminobutyrate aminotransferase GabT",
+      "organism": "Escherichia coli (strain K12)",
+      "ec_numbers": ["2.6.1.19", "2.6.1.48"],
+      "cofactors": ["pyridoxal 5'-phosphate"],
+      "expression_score": 0.7273,
+      "tc_numbers": [],
+      "organism_lineage": ["Bacteria", "Pseudomonadati", "Pseudomonadota"],
+      "length": 426
     }
   ],
   "filter_stats": { "...": "counts before/after each filter" },
@@ -212,11 +227,11 @@ per-function overview:
 {
   "clusters": [
     {
-      "ec_labels": ["1.1.1.1"],
-      "cluster_key": "1.1.1.1",
-      "best_score": 0.87,
+      "ec_labels": ["2.6.1.19"],
+      "cluster_key": "2.6.1.19",
+      "best_score": 0.915,
       "total_in_cluster": 12,
-      "members": [ { "id": "P12345", "score": 0.87 } ]
+      "members": [ { "id": "P22256", "score": 0.915 } ]
     }
   ],
   "total_clusters": 34,
@@ -273,6 +288,37 @@ you omit it.
 
 ---
 
+## 5a. List available cofactors
+
+`GET /cofactors` returns every cofactor annotated in a screening set, with the
+number of enzymes carrying it, most common first. Use it to discover exactly what
+`cofactor_include` / `cofactor_exclude` can filter on.
+
+```bash
+curl https://api.horizyn1.dayhofflabs.com/cofactors \
+  -H "Authorization: Bearer $HORIZYN_API_KEY"
+```
+
+```json
+{
+  "screening_set": "...",
+  "cofactors": [
+    {"name": "Mg(2+)", "count": 857150},
+    {"name": "Zn(2+)", "count": 342243},
+    {"name": "pyridoxal 5'-phosphate", "count": 208973},
+    {"name": "FAD", "count": 133685}
+  ]
+}
+```
+
+Annotations come from UniProt and use ChEBI names, so the stored value is
+`pyridoxal 5'-phosphate` rather than `PLP`. Filters accept either, along with
+other common acronyms (`"SAM"`, `"TPP"`, `"PQQ"`, `"B12"`) and element names
+(`"zinc"`), case-insensitively — but this endpoint is the authoritative list of
+what is actually annotated.
+
+---
+
 ## 6. Validate SMILES before querying
 
 These endpoints check that your input parses, without running a search. They are
@@ -285,7 +331,7 @@ discovering a typo via a `400` on a full query.
 curl -X POST https://api.horizyn1.dayhofflabs.com/validate/reaction \
   -H "Authorization: Bearer $HORIZYN_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"smiles": "CCO>>CC=O"}'
+  -d '{"smiles": "[NH3+]CCCCCC([O-])=O.[O-]C(=O)CCC(=O)C([O-])=O>>[O-]C(=O)CCCCC=O.[NH3+][C@@H](CCC([O-])=O)C([O-])=O"}'
 ```
 
 ```json
@@ -316,34 +362,34 @@ about it. Both endpoints search the default screening set unless you pass a
 **Annotations from the screening set:**
 
 ```bash
-curl "https://api.horizyn1.dayhofflabs.com/protein/P12345/details" \
+curl "https://api.horizyn1.dayhofflabs.com/protein/P22256/details" \
   -H "Authorization: Bearer $HORIZYN_API_KEY"
 ```
 
 ```json
 {
-  "protein_id": "P12345",
-  "name": "Alcohol dehydrogenase",
-  "ec_numbers": ["1.1.1.1"],
-  "organism": "Escherichia coli",
-  "cofactors": ["NAD(+)"],
-  "expression_score": 0.72,
-  "tc_numbers": null,
-  "organism_lineage": ["Bacteria", "Proteobacteria"],
-  "length": 375
+  "protein_id": "P22256",
+  "name": "4-aminobutyrate aminotransferase GabT",
+  "ec_numbers": ["2.6.1.19", "2.6.1.48"],
+  "organism": "Escherichia coli (strain K12)",
+  "cofactors": ["pyridoxal 5'-phosphate"],
+  "expression_score": 0.7273,
+  "tc_numbers": [],
+  "organism_lineage": ["Bacteria", "Pseudomonadati", "Pseudomonadota"],
+  "length": 426
 }
 ```
 
 **Literature and structure references** (fetched live from UniProt):
 
 ```bash
-curl "https://api.horizyn1.dayhofflabs.com/protein/P12345/references" \
+curl "https://api.horizyn1.dayhofflabs.com/protein/P22256/references" \
   -H "Authorization: Bearer $HORIZYN_API_KEY"
 ```
 
 ```json
 {
-  "description": "Alcohol dehydrogenase",
+  "description": "4-aminobutyrate aminotransferase GabT",
   "annotation_score": 5.0,
   "literature": [
     {"title": "...", "citation_type": "journal article", "journal": "...", "publication_date": "1998", "pubmed_id": "..."}
@@ -450,14 +496,15 @@ def query_reaction(smiles: str, **options) -> dict:
     raise RuntimeError("still rate limited after 5 attempts")
 
 
-# Enzymes that oxidize ethanol to acetaldehyde, using a nicotinamide cofactor,
-# and small enough to be practical to express. `top_k` is deliberately large
-# because these filters are narrow — see the note in section 4.
+# PLP-dependent transaminases for the GabT reaction, small enough to be
+# practical to express. `top_k` is deliberately large because these filters are
+# narrow — see the note in section 4.
 data = query_reaction(
-    "CCO>>CC=O",
+    "[NH3+]CCCCCC([O-])=O.[O-]C(=O)CCC(=O)C([O-])=O"
+    ">>[O-]C(=O)CCCCC=O.[NH3+][C@@H](CCC([O-])=O)C([O-])=O",
     top_k=1000,
     page_size=10,
-    cofactor_include=["NAD"],
+    cofactor_include=["PLP"],
     max_length=600,
 )
 

--- a/horizyn-user-manual.md
+++ b/horizyn-user-manual.md
@@ -667,7 +667,8 @@ CSV file with columns:
 | reaction_id | STRING | Unique reaction ID |
 | reaction_smiles | STRING | Reaction SMILES string |
 
-Format: `reactants>>products` (e.g., `CC(=O)O>>CO.CC(=O)`)
+Format: `reactants>>products`, balanced, with cosubstrates included (e.g. methyl
+acetate hydrolysis, `CC(=O)OC.O>>CC(=O)O.CO`)
 
 #### 4. Test Reactions (`test_rxns.csv`)
 


### PR DESCRIPTION
Docs-only. Companion to the API fix in dayhofflabs/horizyn-public-api#9, which fixes the cofactor filtering this guide previously documented as intended behaviour.

## Balanced example reaction

> "we should probably use a balanced reaction for the example in the readme. lets replace CCO>>CC=O with something else so people dont think they can just put in unbalanced stuff (e.g. the gabT reaction is fine)"

`CCO>>CC=O` (ethanol → acetaldehyde) is missing 2 H. Replaced with Josh's suggested GabT transamination:

```
[NH3+]CCCCCC([O-])=O.[O-]C(=O)CCC(=O)C([O-])=O>>[O-]C(=O)CCCCC=O.[NH3+][C@@H](CCC([O-])=O)C([O-])=O
```

Verified with RDKit as balanced on **atoms and charge** (C11H17NO7, −2 each side). It's also an existing regression-suite case (EC 2.6.1.19, top hit P22256 @ 0.9150), so it's a realistic query rather than a toy. Each example now carries a note to balance reactions and include cosubstrates.

Placeholder `P12345`/"Alcohol dehydrogenase" response bodies are replaced with P22256's real annotations, read from the production metadata. That ties this to the API fix: GabT is annotated `pyridoxal 5'-phosphate`, so the Python example now filters `cofactor_include=["PLP"]` on an enzyme that genuinely has it.

## Corrected cofactor filter documentation

The guide previously documented the filter's behaviour accurately — but that behaviour was a bug:

> Cofactor names are matched as case-sensitive *substrings* of the annotation … whereas `"NAD+"` matches nothing at all.

Measured against production, that meant `PLP`, `SAM`, `TPP`, `PQQ`, `NAD+`, and any capitalized word (`Heme`) all matched **zero** of 6.33M proteins, while `FAD`/`FMN`/`NAD` worked only because those acronyms happen to be the ChEBI names. Now fixed upstream, so the guide describes the new semantics: acronyms, element names, and ChEBI spellings all work, case-insensitively, and unmatched terms surface in `warnings`.

Also documents the new `GET /cofactors` endpoint (new § 5a — inserted as `5a` to avoid renumbering the whole guide) and the two caveats that make cofactor filters surprising regardless of matching: annotations are sparse (~2/3 of enzymes have none, so an include filter drops all of them) and filtering happens after the `top_k` search, so narrow filters need a large `top_k`.

## Also

Fixed an unbalanced, chemically nonsensical reaction-format example in the user manual (`CC(=O)O>>CO.CC(=O)` → methyl acetate hydrolysis, `CC(=O)OC.O>>CC(=O)O.CO`, verified balanced).

## Test plan

- [x] GabT reaction verified balanced on atoms and charge with RDKit
- [x] Replacement user-manual reaction verified balanced
- [x] P22256's annotations read from the production parquet rather than invented
- [x] No stale `CCO>>CC=O` / `P12345` / "Alcohol dehydrogenase" references remain in user-facing docs
- [x] Table-of-contents anchor added for the new § 5a
- [ ] Reviewer sanity-check that the reaction reads correctly to a chemist

No code changes, so no test suite implications.

Made with [Cursor](https://cursor.com)