### PR TITLE
docs: sync the public API guide with the hardened API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Official implementation of the [Horizyn model](https://www.pnas.org/doi/10.1073/
 Two ways to use Horizyn:
 
 - **This repository** — train the model, reproduce the paper's evaluation, and run predictions locally against ~216K bundled protein embeddings. Requires a GPU.
-- **The hosted Horizyn API** — search 6.33M enzymes with annotations and filtering, no GPU required. Free API keys are issued by email; see the **[Horizyn API Guide](horizyn-api-guide.md)**.
+- **The hosted Horizyn API** — search 6.33M enzymes with annotations and filtering, no need for a GPU or to clone this repo. Free API keys are issued by email; see the **[Horizyn API Guide](horizyn-api-guide.md)**.
 
 ## Overview
 

--- a/horizyn-api-guide.md
+++ b/horizyn-api-guide.md
@@ -8,6 +8,12 @@ more).
 
 Anyone can get a key — it takes one email round-trip and no account or password.
 
+**You do not need to clone this repository to use the API.** It is plain HTTP and
+JSON against a hosted service, so a key and `curl` — or any HTTP client in any
+language — is the whole toolchain. Nothing below installs anything from here, and
+none of it needs a GPU or a local data download. The repository is for training
+the model or running it offline yourself; the two are independent.
+
 **Base URL:**
 
 ```
@@ -25,33 +31,50 @@ a client in your language of choice.
 
 ## Table of Contents
 
-1. [Hosted API vs. this repository](#1-hosted-api-vs-this-repository)
-2. [Get an API key](#2-get-an-api-key)
-3. [Authenticate](#3-authenticate)
-4. [Search for enzymes by reaction](#4-search-for-enzymes-by-reaction)
-5. [List available screening sets](#5-list-available-screening-sets)
-5a. [List available cofactors](#5a-list-available-cofactors)
-6. [Validate SMILES before querying](#6-validate-smiles-before-querying)
-7. [Look up an enzyme](#7-look-up-an-enzyme)
-8. [Rate limits](#8-rate-limits)
-9. [Errors](#9-errors)
-10. [Python example](#10-python-example)
+- [Horizyn API Guide](#horizyn-api-guide)
+  - [Table of Contents](#table-of-contents)
+  - [1. Hosted API vs. this repository](#1-hosted-api-vs-this-repository)
+  - [2. Get an API key](#2-get-an-api-key)
+    - [Step 1 — request a verification code](#step-1--request-a-verification-code)
+    - [Step 2 — confirm and receive your key](#step-2--confirm-and-receive-your-key)
+    - [Things worth knowing](#things-worth-knowing)
+  - [3. Authenticate](#3-authenticate)
+  - [4. Search for enzymes by reaction](#4-search-for-enzymes-by-reaction)
+    - [Request fields](#request-fields)
+    - [Response (flat list)](#response-flat-list)
+    - [`warnings`: a filter term that can match nothing names itself](#warnings-a-filter-term-that-can-match-nothing-names-itself)
+    - [Response (clustered)](#response-clustered)
+  - [5. List available screening sets](#5-list-available-screening-sets)
+  - [5a. List available cofactors](#5a-list-available-cofactors)
+  - [6. Validate SMILES before querying](#6-validate-smiles-before-querying)
+  - [7. Look up an enzyme](#7-look-up-an-enzyme)
+  - [8. Rate limits](#8-rate-limits)
+    - [One allowance per key, shared across endpoints](#one-allowance-per-key-shared-across-endpoints)
+    - [Request body size](#request-body-size)
+    - [Capacity](#capacity)
+  - [9. Errors](#9-errors)
+  - [10. Python example](#10-python-example)
+    - [One-time: get a key](#one-time-get-a-key)
+    - [Querying](#querying)
+    - [Inspecting a hit](#inspecting-a-hit)
+  - [Questions](#questions)
 
 ---
 
 ## 1. Hosted API vs. this repository
 
-The two are complementary; which you want depends on your goal.
+The two are complementary, and neither needs the other. **Using the API requires
+nothing from this repository** — no clone, no install, no download.
 
 | | This repository | Hosted API |
 |---|---|---|
 | **Enzymes searched** | ~216K bundled protein embeddings | 6.33M proteins |
-| **Setup** | Install deps, download ~1GB data + checkpoint | Request a key by email |
+| **Setup** | Install deps, download ~1GB data + checkpoint | Request a key by email; nothing to install |
 | **Hardware** | NVIDIA GPU with 16GB+ VRAM | None — runs server-side |
 | **Annotations** | Not included | Name, organism, EC, cofactors, literature, structures |
 | **Filtering / clustering** | Not included | EC, transporter class, cofactor, length; EC clustering |
 | **Retraining, custom data** | Yes | No |
-| **Offline / no rate limit** | Yes | 60 req/min, 10,000 req/month |
+| **Offline / no rate limit** | Yes | 60 req/min, 10,000 req/month per key |
 
 Use the repository to reproduce the paper, retrain the model, or run fully
 offline. Use the API to screen against far more enzymes than the bundled set,
@@ -101,9 +124,12 @@ the key for your own reference.
 
 - The verification code **expires 15 minutes** after it is sent.
 - You must wait **60 seconds** between verification requests for the same email
-  address.
+  address, and one source address may request at most **2 codes per hour**. A
+  request inside either window still returns the `202` body above, but no email
+  is sent — so if nothing arrives, wait rather than retrying immediately.
 - After **5 incorrect** code attempts the code is invalidated — request a new
-  one.
+  one. `/keys/confirm` also accepts at most **10 attempts per email per hour**;
+  beyond that it returns `429` with a `Retry-After` header.
 - Treat the key like a password. Keep it out of source control; prefer an
   environment variable, as in the examples below.
 
@@ -117,8 +143,13 @@ Send your key as a bearer token on every data request:
 Authorization: Bearer hzk_live_xxxxxxxx...
 ```
 
-The two `/keys/*` endpoints above are the only unauthenticated ones. Any other
-request without a valid key returns `401 Unauthorized`.
+The two `/keys/*` endpoints above need no key, and neither do `/healthz`, `/docs`
+and `/openapi.json`. Every other request without a valid key returns
+`401 Unauthorized`.
+
+Repeated failed authentications are budgeted per source address: after 120
+failures in a rolling minute, that address receives `429` with `Retry-After`
+instead of `401` until the window rolls over.
 
 ---
 
@@ -145,33 +176,39 @@ curl -X POST https://api.horizyn1.dayhofflabs.com/query/reaction \
 
 ### Request fields
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `smiles` | string | — (required) | Reaction SMILES, using `>>` between reactants and products |
-| `screening_set` | string | default set | Which enzyme library to search. Omit it to use the default; see [§ 5](#5-list-available-screening-sets) |
-| `top_k` | int | `100` | How many nearest enzymes to retrieve before filtering/paging |
-| `page` | int | `1` | Page number of results to return |
-| `page_size` | int | `20` | Results per page |
-| `cluster_by` | string | `null` | Group results by EC number instead of returning a flat list: `"ec3"` (first three EC fields) or `"ec4"` (all four) |
-| `cluster_size` | int | `5` | Members shown per cluster when clustering |
-| `fetch_metadata` | bool | `true` | Attach enzyme annotations (name, organism, EC, etc.) to results |
-| `ec_include` / `ec_exclude` | list[string] | `null` | Keep / drop results by EC number prefix |
-| `tc_include` / `tc_exclude` | list[string] | `null` | Keep / drop results by transporter classification |
-| `cofactor_include` / `cofactor_exclude` | list[string] | `null` | Keep / drop results by cofactor. Accepts acronyms (`"PLP"`, `"SAM"`, `"TPP"`), element names (`"zinc"`), and ChEBI spellings; case-insensitive |
-| `min_length` / `max_length` | int | `null` | Keep results within a sequence-length range |
+Every field carries an explicit limit, and exceeding one returns `422` naming the
+field. Unknown fields are rejected rather than ignored.
 
-Note that `top_k` is applied *before* filtering, so aggressive filters combined
-with a small `top_k` can return very few rows. Raise `top_k` if you are filtering
-hard.
+| Field | Type | Default | Limit | Description |
+|-------|------|---------|-------|-------------|
+| `smiles` | string | — (required) | 2048 chars total, 1024 per side, 768 per component | Reaction SMILES, using `>>` between reactants and products |
+| `screening_set` | string | default set | 46 chars | Which enzyme library to search. Omit it or send `null` to use the default; see [§ 5](#5-list-available-screening-sets) |
+| `top_k` | int | `100` | **1–1000** | How many nearest enzymes to retrieve before filtering/paging |
+| `page` | int | `1` | 1–1000 | Page number of results to return |
+| `page_size` | int | `20` | 1–1000 | Results per page |
+| `cluster_by` | string | `null` | `"ec3"` or `"ec4"` | Group results by EC number instead of returning a flat list: `"ec3"` (first three EC fields) or `"ec4"` (all four). **Any other value returns `422`** |
+| `cluster_size` | int | `5` | 1–1000 | Members shown per cluster when clustering |
+| `fetch_metadata` | bool | `true` | — | Attach enzyme annotations (name, organism, EC, etc.) to results |
+| `ec_include` / `ec_exclude` | list[string] | `null` | ≤190 terms, ≤110 chars each | Keep / drop results by EC number prefix |
+| `tc_include` / `tc_exclude` | list[string] | `null` | ≤190 terms, ≤110 chars each | Keep / drop results by transporter classification |
+| `cofactor_include` / `cofactor_exclude` | list[string] | `null` | ≤190 terms, ≤110 chars each | Keep / drop results by cofactor. Accepts acronyms (`"PLP"`, `"SAM"`, `"TPP"`), element names (`"zinc"`), and ChEBI spellings; case-insensitive |
+| `min_length` / `max_length` | int | `null` | 0–90,708 | Keep results within a sequence-length range. `min_length > max_length` returns `422` rather than an empty result set |
+
+`top_k` is applied *before* filtering, so aggressive filters combined with a small
+`top_k` can return very few rows — raise it, up to the ceiling of 1000.
+
+**That ceiling of 1000 is a hard one, and paging is not a way around it.** `page`
+and `page_size` slice *within* the `top_k` pool rather than extending it, so 1000
+rows is the largest result set any single query can produce. A larger `top_k`
+returns `422`; if you previously used `top_k: 5000`, that is a breaking change
+with no client-side substitute.
 
 Cofactor filters accept common acronyms and names as well as the ChEBI spellings
 used in the annotations, and matching is case-insensitive. All of `"PLP"`,
 `"pyridoxal phosphate"` and `"pyridoxal 5'-phosphate"` select the same
 PLP-dependent enzymes; `"SAM"`, `"TPP"`, `"PQQ"`, `"B12"`, `"zinc"` and `"Heme"`
-work too. A term matching no cofactor in the screening set is reported in the
-response's `warnings` rather than silently returning nothing. Call
-`GET /cofactors` to list every annotated cofactor with enzyme counts. EC and
-transporter-class filters match by prefix instead.
+work too. Call `GET /cofactors` to list every annotated cofactor with enzyme
+counts. EC and transporter-class filters match by prefix instead.
 
 Two caveats specific to cofactor filters: annotations are sparse — roughly two
 thirds of enzymes have no cofactor annotation at all, and a `cofactor_include`
@@ -217,6 +254,29 @@ test, not evidence of catalytic activity.
 `id` is the UniProt accession, which you can pass to the protein endpoints in
 section 7.
 
+### `warnings`: a filter term that can match nothing names itself
+
+An empty result set is ambiguous — it can mean "nothing scored well enough" or
+"you filtered on a term this library has never heard of". A filter term that
+matches **no value anywhere in the screening set** is named in `warnings` instead
+of silently returning zero rows:
+
+```json
+{
+  "warnings": [
+    "ec_include: no protein in this screening set is annotated with EC '9.9.9'. EC numbers are hierarchical, so a prefix such as '1.1' matches every number beneath it.",
+    "cofactor_include: no cofactor in this screening set matches 'unobtainium'. Cofactors are annotated with ChEBI names; see GET /cofactors for the values available."
+  ]
+}
+```
+
+This covers `ec_include`/`ec_exclude`, `tc_include`/`tc_exclude`, and
+`cofactor_include`/`cofactor_exclude`. The check runs against the set's distinct
+annotated values, so a warning means "this term can never match in this library" —
+not "it happened to match nothing among this query's top hits", which is a normal
+outcome and is not warned about. `filter_stats` reports how many results each
+filter stage kept.
+
 ### Response (clustered)
 
 If you set `cluster_by`, results are grouped by EC number instead. This helps
@@ -238,6 +298,7 @@ per-function overview:
   "page": 1,
   "page_size": 20,
   "total_pages": 2,
+  "filter_stats": { "...": "counts before/after each filter" },
   "timings_ms": { "total": 150.0 },
   "quality_warnings": [],
   "warnings": [],
@@ -246,7 +307,9 @@ per-function overview:
 ```
 
 Results with no usable EC annotation are grouped under an empty cluster key.
-Pagination applies to clusters rather than individual enzymes.
+Pagination applies to clusters rather than individual enzymes. `cluster_by`
+accepts only `"ec3"` and `"ec4"`; anything else returns `422` rather than
+falling back to `"ec3"` and quietly answering a different question.
 
 ---
 
@@ -317,6 +380,10 @@ other common acronyms (`"SAM"`, `"TPP"`, `"PQQ"`, `"B12"`) and element names
 (`"zinc"`), case-insensitively — but this endpoint is the authoritative list of
 what is actually annotated.
 
+Filtering applies to the `top_k` nearest enzymes rather than the whole library, so
+pair a narrow cofactor filter with a large `top_k`. The maximum is **1000**, which
+is therefore also the most any filter has to work with.
+
 ---
 
 ## 6. Validate SMILES before querying
@@ -324,6 +391,10 @@ what is actually annotated.
 These endpoints check that your input parses, without running a search. They are
 useful for giving users fast feedback in an interactive tool, and cheaper than
 discovering a typo via a `400` on a full query.
+
+Both take the same `smiles` length limits as a query — 2048 chars total, 1024 per
+side, 768 per component — and both draw on the same per-key allowance as a search
+(see [§ 8](#8-rate-limits)).
 
 **Reaction:**
 
@@ -376,7 +447,8 @@ curl "https://api.horizyn1.dayhofflabs.com/protein/P22256/details" \
   "expression_score": 0.7273,
   "tc_numbers": [],
   "organism_lineage": ["Bacteria", "Pseudomonadati", "Pseudomonadota"],
-  "length": 426
+  "length": 426,
+  "metadata_source": "parquet"
 }
 ```
 
@@ -402,25 +474,57 @@ curl "https://api.horizyn1.dayhofflabs.com/protein/P22256/references" \
 Responses may gain additional fields over time; parse defensively and ignore
 keys you do not recognize.
 
+The `{id}` path segment is constrained to `[A-Za-z0-9._:-]`, at most 82
+characters; anything else returns `422` without a lookup.
+
 ---
 
 ## 8. Rate limits
+
+### One allowance per key, shared across endpoints
 
 Each key is limited to:
 
 - **60 requests per minute**
 - **10,000 requests per month**
 
-Exceeding either returns `429 Too Many Requests`, with a `Retry-After` header in
-seconds and a body like:
+This is **one shared allowance across all seven authenticated endpoints**, not a
+separate budget per endpoint. `/query/reaction`, `/validate/reaction`,
+`/validate/compound`, `/screening_sets`, `/cofactors`, `/protein/{id}/details`
+and `/protein/{id}/references` all draw on the same counter, so a cheap
+`/screening_sets` call spends the same quota as a search.
+
+Exceeding either limit returns `429 Too Many Requests`, with a `Retry-After`
+header in seconds and a body like:
 
 ```json
 {"error": "rate limited", "retry_after": 42}
 ```
 
-The service also caps total concurrent queries, so you may briefly receive a
-`429` even when under your own limits. In both cases, wait `Retry-After` seconds
-and retry.
+Quota is charged **before** the request body is validated on every enveloped
+endpoint except `/query/reaction`, so a request that fails schema validation with
+a `422` has already spent a unit. Fix client-side validation errors rather than
+retrying them in a loop.
+
+### Request body size
+
+Request bodies are capped at **512 KiB** (524,288 bytes). A larger body returns
+`413 Payload Too Large`, enforced on bytes actually received rather than on the
+`Content-Length` you declare. A client that announces a body and then stops
+sending is disconnected with `408 Request Timeout` after 30 seconds.
+
+### Capacity
+
+The service runs a single GPU worker, so it also sheds load when saturated,
+independently of your own allowance:
+
+| Response | Cause |
+|----------|-------|
+| `429` | The concurrency gate or the fingerprinting pool is full. Retry after `Retry-After`. |
+| `503` | A fingerprinting worker died, or the rate-limit counter store could not be reached. Both are transient and retryable — the service fails closed rather than admitting a request it cannot account for. |
+| `504` | The query exceeded its 60-second budget. Retry, optionally with a smaller `top_k`. |
+
+In every case, wait `Retry-After` seconds (where present) and retry.
 
 If your work needs more than these limits, get in touch at
 [info@dayhofflabs.com](mailto:info@dayhofflabs.com).
@@ -434,17 +538,31 @@ If your work needs more than these limits, get in touch at
 | `400` | Invalid input (e.g. malformed reaction SMILES). Body includes `quality_warnings`. Also returned for an incorrect verification code. |
 | `401` | Missing or invalid API key. |
 | `404` | Unknown screening set, or protein not found. |
-| `422` | Request body failed schema validation — a missing required field, a wrong type, or an unusable email address on `/keys/*`. The body names the offending field. |
-| `429` | Rate limited, or server briefly at capacity — see `Retry-After`. |
-| `503` | Service not ready, or verification email temporarily unavailable. Retry shortly. |
+| `408` | A declared request body stopped arriving mid-send. |
+| `413` | Request body exceeded 512 KiB. |
+| `422` | Request failed validation — a missing required field, a wrong type, an unknown field, a value past one of the limits in [§ 4](#4-search-for-enzymes-by-reaction), an unrecognized `cluster_by`, or an unusable email address on `/keys/*`. The body names the offending field. |
+| `429` | Rate limited, server briefly at capacity, or too many failed authentications — see `Retry-After`. |
+| `503` | Service not ready, a worker died, the rate-limit counter store is unreachable, or verification email is temporarily unavailable. Retry shortly. |
 | `504` | Query timed out. Retry, optionally with a smaller `top_k`. |
+
+Error bodies name the field and the limit but never echo the value you sent, so a
+`422` on a large payload stays small.
+
+Malformed, oversized, and pathological input is answered with a `4xx`. If you do
+receive a `500`, it is a bug — please report it with the request that caused it.
+
 ---
 
 ## 10. Python example
 
-The API is plain HTTP + JSON, so no SDK is needed. These examples use
-[`requests`](https://requests.readthedocs.io/), which is a dependency of this
-repository — if you are working outside it, `pip install requests`.
+The API is plain HTTP + JSON, so no SDK is needed and nothing from this
+repository is involved. These examples need only
+[`requests`](https://requests.readthedocs.io/) in whatever environment you
+already have:
+
+```bash
+pip install requests
+```
 
 ### One-time: get a key
 
@@ -487,17 +605,17 @@ def query_reaction(smiles: str, **options) -> dict:
 
     for _ in range(5):
         resp = session.post(f"{BASE}/query/reaction", json=payload, timeout=120)
-        if resp.status_code == 429:
+        if resp.status_code in (429, 503):
             time.sleep(int(resp.headers.get("Retry-After", 5)))
             continue
         resp.raise_for_status()
         return resp.json()
 
-    raise RuntimeError("still rate limited after 5 attempts")
+    raise RuntimeError("still being refused after 5 attempts")
 
 
 # PLP-dependent transaminases for the GabT reaction, small enough to be
-# practical to express. `top_k` is deliberately large because these filters are
+# practical to express. `top_k` is at its 1000 maximum because these filters are
 # narrow — see the note in section 4.
 data = query_reaction(
     "[NH3+]CCCCCC([O-])=O.[O-]C(=O)CCC(=O)C([O-])=O"
@@ -507,6 +625,11 @@ data = query_reaction(
     cofactor_include=["PLP"],
     max_length=600,
 )
+
+# Anything here means a filter term matched nothing in the library — check it
+# before concluding that no enzyme fits.
+for warning in data["warnings"]:
+    print("warning:", warning)
 
 for hit in data["results"]:
     print(f"{hit['score']:.3f}  {hit['id']:10s}  {hit['name']} ({hit['organism']})")


### PR DESCRIPTION
## Summary

`horizyn-api-guide.md` is the only public-facing documentation for the hosted API, and it was written before the input-hardening work. It documented the pre-hardening contract:

- **`top_k` was unbounded.** It caps at **1000**, and paging does not extend it — `page`/`page_size` slice within the pool. This is a breaking change for anyone who was using `top_k: 5000`.
- **`cluster_by` accepted any value.** Only `"ec3"` and `"ec4"` now; the silent `ec3` fallback is gone and anything else is a `422`.
- **No field limits were published at all.** Now tabulated: `smiles` (2048 total / 1024 per side / 768 per component), filter lists (≤190 terms, ≤110 chars each), `min_length`/`max_length` (0–90,708), `screening_set` (46), `page`/`page_size`/`cluster_size` (1–1000), and unknown fields rejected rather than ignored.
- **`408` and `413` were undocumented**, as was the 512 KiB body ceiling and its 30 s stall deadline.
- **Rate limits read as per-endpoint.** They are one envelope shared across all seven authenticated endpoints, and quota is charged before body validation on six of them.
- **`warnings` was described as cofactor-only.** It now covers EC and TC too, with the response shape shown.
- **`/keys/*` was called the only unauthenticated route** — `/healthz`, `/docs` and `/openapi.json` are as well. The per-IP code cap, the 10/hour confirm throttle and the 120/min auth-failure budget were all missing.
- **`protein_id` now has an allowlist** (`[A-Za-z0-9._:-]`, ≤82) that `422`s before any lookup.

It also now states up front that **using the API requires nothing from this repository** — no clone, install, GPU or data download. The Python section previously contradicted this by sourcing `requests` from the repo's dependencies.

## Verification

Every published figure was checked against the deployed service rather than against the source or the plan notes:

- `GET /openapi.json` (no key required) — all field limits, bounds, enums and `additionalProperties: false` match exactly.
- A 600 KiB body returns `413` with the documented 524,288-byte message.
- A keyless request returns `401`; `/healthz` and `/docs` answer `200` without a key.
- §5's "there is currently one screening set" was checked rather than assumed: prod's EFS access point roots at `/horizyn_public_api`, so it reads the single-set registry, and prod query-log records all resolve `eve5_prots`. The elided `screening_set_id`/`description` placeholders are filled in with the real values.

## Test plan

- [ ] Read the rendered diff; confirm the tone matches the rest of the guide
- [ ] Confirm the `top_k` breaking-change wording is what we want external users to read
- [ ] Confirm we are happy publishing the exact limit values (they are already visible in `/openapi.json`)
